### PR TITLE
fix: friends 타이틀 외부영역 버그 수정

### DIFF
--- a/frontend/src/pages/Friends.js
+++ b/frontend/src/pages/Friends.js
@@ -39,18 +39,18 @@ export default function Friends() {
     const $friendList = document.querySelector(".friendList");
     const $blockedList = document.querySelector(".blockedList");
 
-    $friendsWrapper.removeChild($list);
-
     if (e.target.classList.contains("friendList")) {
       $friendList.classList.add("friendsTitleSelect");
       $blockedList.classList.remove("friendsTitleSelect");
 
+      $friendsWrapper.removeChild($list);
       $list = FriendList();
       $friendsWrapper.appendChild($list);
     } else if (e.target.classList.contains("blockedList")) {
       $friendList.classList.remove("friendsTitleSelect");
       $blockedList.classList.add("friendsTitleSelect");
 
+      $friendsWrapper.removeChild($list);
       $list = BlockedList();
       $friendsWrapper.appendChild($list);
     }


### PR DESCRIPTION
## ✅ PR 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 수정
- [ ] 기능에 영향을 주지 않는 변경사항
- [ ] 기능 향상
- [ ] 파일 or 폴더명 수정
- [ ] 파일 or 폴더 삭제

## 📰 관련 이슈
<!---- 아래에 주소에 이슈번호를 넣어주세요! ---->
<!---- ex) https://github.com/42EASY/PongPongPingPong/issues/1 ---->
- https://github.com/42EASY/PongPongPingPong/issues/67

## 📝 PR 내용
<!---- 해당 PR에 어떤 작업을 하였는지 설명해주세요. ---->
friends 사이드바의 타이틀 외부 영역 클릭 시, 목록 부분이 삭제되는 버그 수정하였습니다.
