### PR TITLE
fix: refresh_token 쿠키에 저장하도록 변경

### DIFF
--- a/backend/transcendence/transcendence/settings.py
+++ b/backend/transcendence/transcendence/settings.py
@@ -234,3 +234,5 @@ CORS_ALLOW_HEADERS = (
     'x-csrftoken',
     'x-requested-with',
 )
+
+CORS_ALLOW_CREDENTIALS=True

--- a/frontend/src/components/Login/Redirect.js
+++ b/frontend/src/components/Login/Redirect.js
@@ -16,6 +16,7 @@ export default function Redirect() {
 
   fetch(url, {
     method: "POST",
+    credentials:'include',
     headers: {
       "content-Type": "application/json",
     },


### PR DESCRIPTION
## ✅ PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 수정
- [ ] 기능에 영향을 주지 않는 변경사항
- [ ] 기능 향상
- [ ] 파일 or 폴더명 수정
- [ ] 파일 or 폴더 삭제

## 📰 관련 이슈
<!---- 아래에 주소에 이슈번호를 넣어주세요! ---->
<!---- ex) https://github.com/42EASY/PongPongPingPong/issues/1 ---->
- https://github.com/42EASY/PongPongPingPong/issues/102

## 📝 PR 내용
<!---- 해당 PR에 어떤 작업을 하였는지 설명해주세요. ---->
refresh_token을 쿠키에 저장하도록 로직을 수정하였습니다. 
배포할 경우 바꿔줘야할 설정들이 존재합니다 .

