### PR TITLE
fix: cookie에서 토큰 가져오도록 수정

### DIFF
--- a/backend/transcendence/security/views.py
+++ b/backend/transcendence/security/views.py
@@ -9,23 +9,22 @@ import jwt
 
 class JwtView(APIView):
 	def post(self, request):
-		header = request.META.get('HTTP_AUTHORIZATION', None)
-		if not header:
+		refresh_token = request.COOKIES.get('refresh_token', None)
+		if not refresh_token:
 			return JsonResponse(
 				{'code':401,
 				'message':'Unauthorized'},
 				status=401
 			)
 		
-		token = header.split()[1]
 		try:
-			Members.objects.get(id=cache.get(token))
+			Members.objects.get(id=cache.get(refresh_token))
 		except Members.DoesNotExist:
 			return JsonResponse({'code': 404, 'message': 'Not Found'}, status=404)
 
 		# 새로운 access_token 생성
 		try:
-			refresh = RefreshToken(token)
+			refresh = RefreshToken(refresh_token)
 			new_access_token = str(refresh.access_token)
 		except:
 			return JsonResponse({'code': 403, 'message': 'Forbbiden'}, status=403)


### PR DESCRIPTION
## ✅ PR 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 수정
- [ ] 기능에 영향을 주지 않는 변경사항
- [ ] 기능 향상
- [ ] 파일 or 폴더명 수정
- [ ] 파일 or 폴더 삭제

## 📰 관련 이슈
<!---- 아래에 주소에 이슈번호를 넣어주세요! ---->
<!---- ex) https://github.com/42EASY/PongPongPingPong/issues/1 ---->
- https://github.com/42EASY/PongPongPingPong/issues/116

## 📝 PR 내용
<!---- 해당 PR에 어떤 작업을 하였는지 설명해주세요. ---->
refresh 토큰을 쿠키에 저장하는 방식으로 바꾸었기때문에, refresh_token으로 access_token을 발급받는 방식도 쿠키에서 가져오도록 변경하였습니다.

