### PR TITLE
fix: websocket을 동기식에서 비동기식으로 수정 및 테스트

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -28,6 +28,8 @@ RUN pip install channels-redis
 RUN pip install daphne
 
 RUN pip install django-cors-headers
+RUN pip install pytest-asyncio
+
 
 RUN apt-get update && apt-get install -y postgresql-client && rm -rf /var/lib/apt/lists/*
 

--- a/backend/transcendence/games/consumers.py
+++ b/backend/transcendence/games/consumers.py
@@ -1,44 +1,42 @@
 import json
-from asgiref.sync import async_to_sync
-from channels.generic.websocket import WebsocketConsumer
+# from asgiref.sync import async_to_sync
+from channels.generic.websocket import AsyncJsonWebsocketConsumer
 
 #TODO: 연결되는 것 확인하기 위해 임시로 코드 작성
-class GameConsumer(WebsocketConsumer):
-    def connect(self):
+class GameConsumer(AsyncJsonWebsocketConsumer):
+    async def connect(self):
         print('hi')
         self.game_id = 10
         self.channel_name = 'hi'
         self.game_group_id = f"game_{self.game_id}"
 
         # Join group
-        async_to_sync(self.channel_layer.group_add)(
+        await self.channel_layer.group_add(
             self.game_group_id, self.channel_name
         )
-        self.accept()
+        await self.accept()
 
-    def disconnect(self, close_code):
-        async_to_sync(self.channel_layer.group_discard)(
+    async def disconnect(self, close_code):
+        await self.channel_layer.group_discard(
             self.game_group_id, self.channel_name
         )
 
-    def receive(self, text_data):
+    #connect 이후 receive 및 send 할 내용 정의
+    async def receive(self, text_data):
         
         print('receive')
-        # Echo message back to the group
-        async_to_sync(self.channel_layer.group_send)(
-            self.game_group_id,
-            {
+
+        await self.send_json({
                 'type': 'game_message',
-                #'message': text_data_json['message']  # Echo back received message
                 'message': 'hello'
-            }
+            }    
         )
 
     # Method to receive message from group
-    def game_message(self, event):
+    async def game_message(self, event):
         message = event['message']
 
         # Send message to WebSocket
-        self.send(text_data=json.dumps({
+        await self.send(text_data=json.dumps({
             'message': message
         }))

--- a/backend/transcendence/games/test_consumer.py
+++ b/backend/transcendence/games/test_consumer.py
@@ -1,0 +1,48 @@
+import asyncio
+import os
+import django
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'transcendence.settings')
+os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
+django.setup()
+
+import pytest
+from channels.testing import WebsocketCommunicator
+from .consumers import GameConsumer
+from channels.layers import get_channel_layer
+import json
+from members.models import Members
+from rest_framework_simplejwt.tokens import RefreshToken
+
+@pytest.mark.asyncio
+async def test_game_consumer():
+
+    channel_layer = get_channel_layer()
+
+    #테스트용 토큰 발급
+    fake_user = Members.objects.create(nickname = 'test_user', email = 'testUser@test.com', is_2fa = False)
+    refresh = RefreshToken.for_user(fake_user)
+    fake_token = str(refresh.access_token)
+
+    #토큰과 함께 /ws/game/<int:room_id> 에 연결
+    communicator = WebsocketCommunicator(GameConsumer.as_asgi(), "/ws/game/42?token=" + fake_token)
+    connected, subprotocol = await communicator.connect()
+
+    assert connected
+
+    #GameConsumer의 receive에 json send
+    await communicator.send_json_to({
+        "type": "game_message",
+        "message": "Test Message"
+    })
+
+    response = await communicator.receive_json_from()    
+
+    #GameConsumser에서 send한 값 테스트
+    assert response == {
+        'type': 'game_message',
+        'message': 'hello'
+    }
+
+    await communicator.disconnect()
+         


### PR DESCRIPTION
## ✅ PR 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 수정
- [ ] 기능에 영향을 주지 않는 변경사항
- [ ] 기능 향상
- [ ] 파일 or 폴더명 수정
- [ ] 파일 or 폴더 삭제

## 📰 관련 이슈
<!---- 아래에 주소에 이슈번호를 넣어주세요! ---->
<!---- ex) https://github.com/42EASY/PongPongPingPong/issues/1 ---->
- https://github.com/42EASY/PongPongPingPong/issues/103

## 📝 PR 내용
<!---- 해당 PR에 어떤 작업을 하였는지 설명해주세요. ---->
- 현재 websocket이 동기식으로 이루어져있는데, 이를 비동기식으로 수정
- 테스트코드 작성 및 테스트 완료
- 테스트 시 shell에서 `pytest (원하는 테스트파일.py)` 명령어로 테스트 가능
