### PR TITLE
fix: websocket connect 시에 user 값 받아오도록 수정

### DIFF
--- a/backend/transcendence/games/game_consumer.py
+++ b/backend/transcendence/games/game_consumer.py
@@ -14,11 +14,7 @@ class GameConsumer(AsyncJsonWebsocketConsumer):
     async def connect(self):
         path = self.scope['path']
         self.game_id = path.strip('/').split('/')[-1]
-        
-        token = parse_qs(self.scope["query_string"].decode("utf8")).get("token", [None])[0]
-
-        decoded_data = jwt_decode(token, settings.SIMPLE_JWT['SIGNING_KEY'], algorithms=["HS256"])
-        self.user = Members.objects.get(id = decoded_data['user_id'])
+        self.user = self.scope['user']
 
         self.lock = DistributedLock()
 

--- a/backend/transcendence/games/game_room_consumer.py
+++ b/backend/transcendence/games/game_room_consumer.py
@@ -11,7 +11,7 @@ class GameRoomConsumer(AsyncJsonWebsocketConsumer):
     async def connect(self):
         path = self.scope['path']
         self.room_id = path.strip('/').split('/')[-1]
-
+        self.user = self.scope['user']
         self.lock = DistributedLock()
 
         try:
@@ -50,7 +50,7 @@ class GameRoomConsumer(AsyncJsonWebsocketConsumer):
 
     #초대를 하는 경우
     async def invite_room(self, text_data_json):
-        user_id = text_data_json["user_id"]
+        # user_id = text_data_json["user_id"]
         invite_user_id = text_data_json["invite_user_id"]
         invite_time = text_data_json["invite_time"]
 
@@ -111,7 +111,7 @@ class GameRoomConsumer(AsyncJsonWebsocketConsumer):
 
     #방에 입장 후 게임 시작 대기
     async def join_room(self, text_data_json):
-        user_id = text_data_json["user_id"]
+        # user_id = text_data_json["user_id"]
 
         #TODO: user_id가 유효한지 검증하기(만일 connect 시에 user id 값을 받아오게 된다면 필요없어지는 로직)
 
@@ -157,7 +157,7 @@ class GameRoomConsumer(AsyncJsonWebsocketConsumer):
         idx = -1
         for user_value in registered_value:
             idx += 1
-            if (user_value["user_id"] == user_id):
+            if (user_value["user_id"] == self.user.id):
                 #channel_id 갱신
                 parsed_value["registered_user"][idx]["channel_id"] = self.channel_name
                 flag = True
@@ -172,7 +172,7 @@ class GameRoomConsumer(AsyncJsonWebsocketConsumer):
 
 
         #join_user에 유저 등록
-        parsed_value["join_user"].append(user_id)
+        parsed_value["join_user"].append(self.user.id)
 
         updated_value = json.dumps(parsed_value)
 
@@ -331,9 +331,7 @@ class GameRoomConsumer(AsyncJsonWebsocketConsumer):
 
     #결승 게임 시작 대기
     async def join_final(self, text_data_json):
-        user_id = text_data_json["user_id"]
-
-        #TODO: user_id가 유효한지 검증하기(만일 connect 시에 user id 값을 받아오게 된다면 필요없어지는 로직)
+        # user_id = text_data_json["user_id"]
 
         key = "tournament_" + str(self.room_id)
 
@@ -374,7 +372,7 @@ class GameRoomConsumer(AsyncJsonWebsocketConsumer):
         idx = -1
         for user_value in registered_value:
             idx += 1
-            if (user_value["user_id"] == user_id):
+            if (user_value["user_id"] == self.user.id):
                 #channel_id 갱신
                 parsed_value["registered_user"][idx]["channel_id"] = self.channel_name
                 flag = True
@@ -389,7 +387,7 @@ class GameRoomConsumer(AsyncJsonWebsocketConsumer):
 
 
         #join_user에 유저 등록
-        parsed_value["join_final_user"].append(user_id)
+        parsed_value["join_final_user"].append(self.user.id)
 
         updated_value = json.dumps(parsed_value)
 

--- a/backend/transcendence/games/test_game_room_consumer.py
+++ b/backend/transcendence/games/test_game_room_consumer.py
@@ -17,6 +17,10 @@ from datetime import datetime
 from rest_framework_simplejwt.tokens import RefreshToken
 from django.core.cache import cache
 
+async def mock_authenticate(scope, user):
+    scope['user'] = user
+    return scope
+
 #게임방 4명 입장 성공 테스트
 @pytest.mark.asyncio
 async def test_join_room_success():
@@ -52,6 +56,7 @@ async def test_join_room_success():
 
     #발급 받은 게임방 아이디로 접속
     communicator = WebsocketCommunicator(GameRoomConsumer.as_asgi(), "/ws/join_room/" + str(tournament.id) +"?token=" + fake_token)
+    communicator.scope = await mock_authenticate(communicator.scope, fake_user)
     connected, subprotocol = await communicator.connect()
 
     assert connected
@@ -114,6 +119,7 @@ async def test_invite_and_join_room_success():
 
     #fake user가 발급 받은 게임방 아이디로 접속
     join_communicator = WebsocketCommunicator(GameRoomConsumer.as_asgi(), "/ws/join_room/" + str(tournament.id) +"?token=" + fake_token)
+    join_communicator.scope = await mock_authenticate(join_communicator.scope, fake_user)
     join_connected, join_subprotocol = await join_communicator.connect()
 
     assert join_connected
@@ -135,6 +141,7 @@ async def test_invite_and_join_room_success():
     
     #fake_user가 초대해서 reponse 받은 room id로 invite_user가 토너먼트 초대 수락
     invite_queue_communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + invite_token)
+    invite_queue_communicator.scope = await mock_authenticate(invite_queue_communicator.scope, invite_user)
     invite_queue_connected, invite_subprotocol = await invite_queue_communicator.connect()
 
     assert invite_queue_connected
@@ -155,6 +162,7 @@ async def test_invite_and_join_room_success():
 
     #초대 수락에 성공한 invite_user가 게임방 아이디로 접속
     invite_communicator = WebsocketCommunicator(GameRoomConsumer.as_asgi(), "/ws/join_room/" + str(tournament.id) +"?token=" + invite_token)
+    invite_communicator.scope = await mock_authenticate(invite_communicator.scope, invite_user) 
     invite_connected, invite_subprotocol = await invite_communicator.connect()
 
     assert invite_connected
@@ -211,6 +219,7 @@ async def test_join_final_room_success():
 
     #another_user가 발급 받은 게임방 아이디로 접속
     another_communicator = WebsocketCommunicator(GameRoomConsumer.as_asgi(), "/ws/join_room/" + str(tournament.id) +"?token=" + another_token)
+    another_communicator.scope = await mock_authenticate(another_communicator.scope, another_user)
     another_connected, another_subprotocol = await another_communicator.connect()
 
     assert another_connected
@@ -222,6 +231,7 @@ async def test_join_final_room_success():
 
     #fake_user가 발급 받은 게임방 아이디로 접속
     communicator = WebsocketCommunicator(GameRoomConsumer.as_asgi(), "/ws/join_room/" + str(tournament.id) +"?token=" + fake_token)
+    communicator.scope = await mock_authenticate(communicator.scope, fake_user)
     connected, subprotocol = await communicator.connect()
 
     assert connected


### PR DESCRIPTION
## ✅ PR 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 수정
- [ ] 기능에 영향을 주지 않는 변경사항
- [ ] 기능 향상
- [ ] 파일 or 폴더명 수정
- [ ] 파일 or 폴더 삭제

## 📰 관련 이슈
<!---- 아래에 주소에 이슈번호를 넣어주세요! ---->
<!---- ex) https://github.com/42EASY/PongPongPingPong/issues/1 ---->
- https://github.com/42EASY/PongPongPingPong/issues/128

## 📝 PR 내용
<!---- 해당 PR에 어떤 작업을 하였는지 설명해주세요. ---->
- 현재 user_id를 action을 보낼 때 마다 같이 보내도록 했는데, 이를 connect 시에 user 정보를 받아와서 더 이상 action에서 user_id를 받아오지 않도록 수정
- token의 유효성을 검사하는 middleware에서 저장하는 user 정보를 받아와서 저장
- 하지만 테스트코드 상에서는 middleware를 타지 않아, 임의로 user 정보를 넣어줌
- 사용하지 않는 user_id와 json data 값들은 다음 pr에서 수정할 예정
