### PR TITLE
feat: join_queue 소켓 추가

### DIFF
--- a/frontend/src/components/Friends/Friend.js
+++ b/frontend/src/components/Friends/Friend.js
@@ -17,7 +17,7 @@ export default function Friend(user) {
   const $optionsIcon = document.createElement("i");
   $optionsIcon.classList.add("bi", "bi-three-dots-vertical");
 
-  const $options = Options(user.user_id);
+  const $options = Options(user.user_id, user.status);
 
   const $friendImage = document.createElement("img");
   $friendImage.classList.add("profileImg");

--- a/frontend/src/components/Friends/Options.js
+++ b/frontend/src/components/Friends/Options.js
@@ -1,7 +1,8 @@
 import changeUrl from "../../Router.js";
 import ChatRoom from "../../pages/ChatRoom.js";
+import { inviteGame } from "../Nav/InviteQueue.js";
 
-export default function Options(id) {
+export default function Options(id, status) {
   const $OptionsWrapper = document.createElement("div");
   $OptionsWrapper.classList.add("optionsWrapper");
 
@@ -29,7 +30,9 @@ export default function Options(id) {
   $gameOpt.classList.add("list-group-item", "optionsItem");
   $gameOpt.innerHTML = "게임 초대하기";
   $Options.appendChild($gameOpt);
-  // todo: 게임 초대하기
+  $gameOpt.addEventListener("click", () => {
+    inviteGame(id, status);
+  });
 
   const $unfriendOpt = document.createElement("li");
   $unfriendOpt.classList.add("list-group-item", "optionsItem", "optionListRed");

--- a/frontend/src/components/GameRoom/WaitingPlayer.js
+++ b/frontend/src/components/GameRoom/WaitingPlayer.js
@@ -1,7 +1,4 @@
-import PercentBar from "./PercentBar.js";
-import TimerRing from "./TimerRing.js";
-
-export default function WaitingPlayer(state) {
+export default function WaitingPlayer(user) {
   const $waitingPlayer = document.createElement("div");
   const $waitingPlayerImageBox = document.createElement("div");
   const $waitingPlayerImage = document.createElement("img");
@@ -16,22 +13,13 @@ export default function WaitingPlayer(state) {
   $waitingPlayer.appendChild($waitingPlayerImageBox);
   $waitingPlayer.appendChild($waitingPlayerName);
 
-  if (state == 1) {
+  if (user) {
+    $waitingPlayerImage.setAttribute("src", user.image_url);
+    $waitingPlayerName.innerHTML = user.nickname;
+  } else {
     $waitingPlayerImage.setAttribute("src", "./src/images/none_profile.png");
     $waitingPlayerName.innerHTML = "대전자 찾는 중...";
     $waitingPlayerName.id = "emptyPlayerName";
-    $waitingPlayer.appendChild(PercentBar({ win: 0, lose: 0 }));
-  } else if (state == 2) {
-    $waitingPlayerImageBox.innerHTML = "";
-    $waitingPlayerImageBox.appendChild(TimerRing());
-    $waitingPlayerImageBox.style.backgroundColor = "transparent";
-    $waitingPlayerName.innerHTML = "nickname님을 기다리는 중...";
-    $waitingPlayerName.id = "emptyPlayerName";
-    $waitingPlayer.appendChild(PercentBar({ win: 0, lose: 0 }));
-  } else {
-    $waitingPlayerImage.setAttribute("src", ""); //profile image path
-    $waitingPlayerName.innerHTML = "nickname"; //player nickname
-    $waitingPlayer.appendChild(PercentBar({ win: 6, lose: 4 }));
   }
 
   return $waitingPlayer;

--- a/frontend/src/components/Main/MoreMenu.js
+++ b/frontend/src/components/Main/MoreMenu.js
@@ -1,6 +1,7 @@
 import OtherBtn from "./OtherBtn.js";
 import Modal from "../Modal/Modal.js";
 import { postBlock } from "./UserApi.js";
+import { inviteGame } from "../Nav/InviteQueue.js";
 
 export default function MoreMenu(user) {
   const $MoreMenuWrapper = document.createElement("div");
@@ -25,13 +26,13 @@ export default function MoreMenu(user) {
   $BlockOption.append("차단하기");
 
   $InviteGameOption.addEventListener("click", () => {
-    // todo: 게임 초대
+    inviteGame(user.user_id, user.status);
   });
 
   $BlockOption.addEventListener("click", () => {
     Modal("blockFriend", user.nickname).then((result) => {
       if (result.isPositive) {
-        postBlock(user.user_id);
+        postBlock(user.user_id, user.status);
         const $ProfileBtnBox = document.querySelector("#profileBtnBox");
         $ProfileBtnBox.innerHTML = "";
         $ProfileBtnBox.appendChild(OtherBtn(user.user_id, "BLOCK"));

--- a/frontend/src/components/Nav/FastGameStart.js
+++ b/frontend/src/components/Nav/FastGameStart.js
@@ -1,38 +1,44 @@
 import Modal from "../Modal/Modal.js";
 import changeUrl from "../../Router.js";
+import {
+  joinNormalQueue,
+  joinTournamentQueue,
+  cancelNormalQueue,
+} from "./JoinQueue.js";
 
-export default function FastGameStart(data) {
+export default function FastGameStart() {
+  let game_mode;
   Modal("gameMode").then((result) => {
     if (result.isPositive && result.input === "2P 게임") {
       Modal("gameOption").then((option) => {
-        if (option.isPositive && option.input === "클래식") {
-          //todo: changeUrl("/game")
-        }
-        if (option.isPositive && option.input === "스피드") {
-          //todo: changeUrl("/game")
+        if (option.isPositive) {
+          if (option.input === "클래식") game_mode = "CLASSIC";
+          else if (option.input === "스피드") game_mode = "SPEED";
+          changeUrl("/game", {
+            option: "2P",
+            mode: game_mode,
+          });
         }
       });
     }
     if (result.isPositive && result.input === "일반 게임") {
       Modal("gameOption").then((option) => {
-        if (option.isPositive && option.input === "클래식") {
-          Modal("waitingPlayer").then((res) => {
-            if (!res.isPositive) {
-              //todo: 게임 대기 취소
-            }
+        if (option.isPositive) {
+          if (option.input === "클래식") game_mode = "CLASSIC";
+          else if (option.input === "스피드") game_mode = "SPEED";
+          joinNormalQueue({
+            action: "join_normal_queue",
+            game_mode: game_mode,
           });
-        }
-        if (option.isPositive && option.input === "스피드") {
           Modal("waitingPlayer").then((res) => {
-            if (!res.isPositive) {
-              //todo: 게임 대기 취소
-            }
+            // 모달 취소하기 버튼 눌렀을 경우
+            if (!res.isPositive) cancelNormalQueue({ action: "" });
           });
         }
       });
     }
     if (result.isPositive && result.input === "토너먼트") {
-      //todo: changeUrl("/gameroom")
+      joinTournamentQueue({ action: "join_tournament_queue" });
     }
   });
 }

--- a/frontend/src/components/Nav/InviteQueue.js
+++ b/frontend/src/components/Nav/InviteQueue.js
@@ -1,0 +1,44 @@
+import Modal from "../Modal/Modal.js";
+import {
+  joinNormalQueue,
+  joinTournamentQueue,
+  cancelNormalQueue,
+} from "./JoinQueue.js";
+
+export function inviteGame(id, status) {
+  if (status === "OFFLINE") {
+    Modal("inviteFail_offline");
+  } else if (status === "IN-GAME") {
+    Modal("inviteFail_offline");
+  } else if (status === "ONLINE") {
+    let game_mode;
+    const modal = Modal("gameMode");
+    const $2p = document.querySelector(".modalBody").firstChild;
+    document.querySelector(".modalBody").removeChild($2p);
+    modal.then((result) => {
+      if (result.isPositive && result.input === "일반 게임") {
+        Modal("gameOption").then((option) => {
+          if (option.isPositive) {
+            if (option.input === "클래식") game_mode = "CLASSIC";
+            else if (option.input === "스피드") game_mode = "SPEED";
+            joinNormalQueue({
+              action: "invite_normal_queue",
+              game_mode: game_mode,
+              invite_user_id: id,
+            });
+            Modal("waitingInvitation").then((res) => {
+              // 모달 취소하기 버튼 눌렀을 경우
+              if (!res.isPositive) cancelNormalQueue({ action: "" });
+            });
+          }
+        });
+      }
+      if (result.isPositive && result.input === "토너먼트") {
+        joinTournamentQueue({
+          action: "invite_tournament_queue",
+          invite_user_id: id,
+        });
+      }
+    });
+  }
+}

--- a/frontend/src/components/Nav/JoinQueue.js
+++ b/frontend/src/components/Nav/JoinQueue.js
@@ -2,7 +2,8 @@ import changeUrl from "../../Router.js";
 import { getAccessToken } from "../../state/State.js";
 
 const url = `ws://0.0.0.0:8000/ws/join_queue/?token=${getAccessToken()}`;
-const socket = new WebSocket(url);
+let socket;
+if (!socket) socket = new WebSocket(url);
 
 socket.onopen = () => {
   console.log("[open]");
@@ -27,8 +28,8 @@ export function joinNormalQueue(data) {
         //todo: chat game_id
       }
       if (res.status === "game_start_soon") {
-        res[mode] = data.game_mode;
-        res[option] = "NORMAL";
+        res["mode"] = data.game_mode;
+        res["option"] = "NORMAL";
         changeUrl("/game", res);
       }
     };
@@ -49,10 +50,13 @@ export function joinTournamentQueue(data) {
     socket.send(JSON.stringify(data));
     socket.onmessage = (e) => {
       let res = JSON.parse(e.data);
+      console.log(res);
       if (res.status === "game create success") {
         //todo: chat room_id
       }
       if (res.status === "success") {
+        res["mode"] = "SEMI_FINAL";
+        console.log(res);
         changeUrl("/gameroom", res);
       }
     };

--- a/frontend/src/components/Nav/JoinQueue.js
+++ b/frontend/src/components/Nav/JoinQueue.js
@@ -1,0 +1,60 @@
+import changeUrl from "../../Router.js";
+import { getAccessToken } from "../../state/State.js";
+
+const url = `ws://0.0.0.0:8000/ws/join_queue/?token=${getAccessToken()}`;
+const socket = new WebSocket(url);
+
+socket.onopen = () => {
+  console.log("[open]");
+};
+
+socket.onclose = (e) => {
+  if (e.wasClean) console.log("[close] - normal");
+  else console.log("[close] - abnormal");
+};
+
+socket.onerror = (e) => {
+  console.log("[error]");
+  console.log(e);
+};
+
+export function joinNormalQueue(data) {
+  if (socket.readyState === WebSocket.OPEN) {
+    socket.send(JSON.stringify(data));
+    socket.onmessage = (e) => {
+      let res = JSON.parse(e.data);
+      if (res.status === "game create success") {
+        //todo: chat game_id
+      }
+      if (res.status === "game_start_soon") {
+        res[mode] = data.game_mode;
+        res[option] = "NORMAL";
+        changeUrl("/game", res);
+      }
+    };
+  }
+}
+
+export function cancelNormalQueue(data) {
+  if (socket.readyState === WebSocket.OPEN) {
+    socket.send(JSON.stringify(data));
+    socket.onmessage = (e) => {
+      console.log(JSON.parse(e.data));
+    };
+  }
+}
+
+export function joinTournamentQueue(data) {
+  if (socket.readyState === WebSocket.OPEN) {
+    socket.send(JSON.stringify(data));
+    socket.onmessage = (e) => {
+      let res = JSON.parse(e.data);
+      if (res.status === "game create success") {
+        //todo: chat room_id
+      }
+      if (res.status === "success") {
+        changeUrl("/gameroom", res);
+      }
+    };
+  }
+}

--- a/frontend/src/pages/Friends.js
+++ b/frontend/src/pages/Friends.js
@@ -104,6 +104,11 @@ export default async function Friends() {
     curPage = 1;
     hasMore = true;
     $searchInput.value = "";
+    $friendsWrapper.scrollTo({ top: 0, left: 0, behavior: "smooth" });
+
+    let childNodes = $listWrapper.childNodes;
+    for (let i = childNodes.length - 1; i > 0; i--)
+      $listWrapper.removeChild(childNodes[i]);
     if (e.target.classList.contains("friendList")) {
       $friendList.classList.add("friendsTitleSelect", "titleSelect");
       $blockedList.classList.remove("friendsTitleSelect", "titleSelect");
@@ -127,9 +132,15 @@ export default async function Friends() {
 
   //검색 입력 이벤트
   const $searchInput = document.getElementById("searchInput");
+  $searchInput.addEventListener("focus", () => {
+    $friendsWrapper.scrollTo({ top: 0, left: 0, behavior: "smooth" });
+  });
   $searchInput.addEventListener("keyup", async () => {
     curPage = 1;
     hasMore = true;
+    let childNodes = $listWrapper.childNodes;
+    for (let i = childNodes.length - 1; i > 0; i--)
+      $listWrapper.removeChild(childNodes[i]);
     if (isFriends) {
       const $data = await fetchFriends($searchInput.value);
       try {
@@ -147,7 +158,7 @@ export default async function Friends() {
     }
   });
 
-  //todo: scroll event
+  //scroll event
   $friendsWrapper.addEventListener("scroll", async () => {
     if (isFetching || !hasMore) return;
     if (


### PR DESCRIPTION
## ✅ PR 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드 수정
- [ ] 기능에 영향을 주지 않는 변경사항
- [ ] 기능 향상
- [ ] 파일 or 폴더명 수정
- [ ] 파일 or 폴더 삭제

## 📰 관련 이슈
<!---- 아래에 주소에 이슈번호를 넣어주세요! ---->
<!---- ex) https://github.com/42EASY/PongPongPingPong/issues/1 ---->
- https://github.com/42EASY/PongPongPingPong/issues/158

## 📝 PR 내용
<!---- 해당 PR에 어떤 작업을 하였는지 설명해주세요. ---->
게임 시작하기 전 join_queue 소켓 추가했습니다!

game페이지로 이동할 때 `changeUrl("/game", data);` 의 data 모음
* 2P game
`data = { option: "2P", mode: ["CLASSIC" | "SPEED"] };`
* normal game
`data = { option: "NORMAL", mode : ["CLASSIC" | "SPEED"], game_id: "1", `
`player_info: [{ user_id, nickname, image_url }, { user_id, nickname, image_url }] };`
* tournament game
`data = { mode: ["SEMI_FINAL" | "FINAL" ], game_id: "1", player_info: {} };`

* 준결승 시합 끝나고 gameroom 이동시 아래처럼 넣어주세요!
`changeUrl("/gameroom", {mode: "FINAL", room_id: id});`



friends의 친구 목록에서 스크롤 한 후 차단목록으로 이동하면 
친구목록의 리스트와 차단목록의 리스트가 겹쳐지는 오류가 있었는데 수정했습니다