### PR TITLE
fix: 게임 빠른 시작 시에 오류 발생 해결

### DIFF
--- a/backend/transcendence/games/test_game_queue_consumer.py
+++ b/backend/transcendence/games/test_game_queue_consumer.py
@@ -26,184 +26,211 @@ async def mock_authenticate(scope, user):
 @pytest.mark.asyncio
 async def test_invited_normal_queue_success():
 
-    channel_layer = get_channel_layer()
+    try:
+        channel_layer = get_channel_layer()
 
-    # 테스트용 토큰 발급(비동기적으로 실행되기에 테스트용 데이터를 pytest.fixture로 하나로 묶을 수 없음)
-    fake_user = Members.objects.create(nickname = 'test_user', email = 'testUser@test.com', is_2fa = False)
-    refresh = RefreshToken.for_user(fake_user)
-    fake_token = str(refresh.access_token)
+        # 테스트용 토큰 발급(비동기적으로 실행되기에 테스트용 데이터를 pytest.fixture로 하나로 묶을 수 없음)
+        fake_user = Members.objects.create(nickname = 'test_a', email = 'testUser@test.com', is_2fa = False)
+        refresh = RefreshToken.for_user(fake_user)
+        fake_token = str(refresh.access_token)
 
-    fake_game = Game.objects.create(game_option='CLASSIC', game_mode='NORMAL')
+        fake_game = Game.objects.create(game_option='CLASSIC', game_mode='NORMAL')
 
-    test_user = Members.objects.create(nickname = 'tt', email = 'tt@test.com', is_2fa = False)
-    value = {
-        "registered_user": [{
-            "user_id" : test_user.id,
-            "channel_id": "123"
-        }],
-        "invited_info": [{
-            "user_id": fake_user.id
-        }]
-    }
+        test_user = Members.objects.create(nickname = 'aa', email = 'tt@test.com', is_2fa = False)
+        value = {
+            "registered_user": [{
+                "user_id" : test_user.id,
+                "channel_id": "123"
+            }],
+            "invited_info": [{
+                "user_id": fake_user.id
+            }]
+        }
 
-    cache.set('normal_' + str(fake_game.id),  json.dumps(value))
+        cache.set('normal_' + str(fake_game.id),  json.dumps(value))
 
-    #토큰과 함께 ws/join_queue 에 연결
-    communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + fake_token)
-    communicator.scope = await mock_authenticate(communicator.scope, fake_user)
-    connected, subprotocol = await communicator.connect()
+        #토큰과 함께 ws/join_queue 에 연결
+        communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + fake_token)
+        communicator.scope = await mock_authenticate(communicator.scope, fake_user)
+        connected, subprotocol = await communicator.connect()
 
-    assert connected
+        assert connected
 
-    await communicator.send_json_to({
-        "action": "join_invite_normal_queue",
-        "game_id": fake_game.id
-    })
+        await communicator.send_json_to({
+            "action": "join_invite_normal_queue",
+            "game_id": fake_game.id
+        })
 
-    response = await communicator.receive_json_from()    
+        response = await communicator.receive_json_from()    
 
-    assert response["status"] == "game_start_soon"
+        assert response["status"] == "game_start_soon"
 
-    await communicator.disconnect()
+        await communicator.disconnect()
+
+    finally:
+        fake_user.delete()
+        fake_game.delete()
+        test_user.delete()
          
 
 #redis에 key가 없는 경우
 @pytest.mark.asyncio
 async def test_invited_normal_queue_fail_no_value():
 
-    channel_layer = get_channel_layer()
+    try:
+        channel_layer = get_channel_layer()
 
-    # 테스트용 토큰 발급(비동기적으로 실행되기에 테스트용 데이터를 pytest.fixture로 하나로 묶을 수 없음)
-    fake_user = Members.objects.create(nickname = 'test_user1', email = 'testUser1@test.com', is_2fa = False)
-    refresh = RefreshToken.for_user(fake_user)
-    fake_token = str(refresh.access_token)
+        # 테스트용 토큰 발급(비동기적으로 실행되기에 테스트용 데이터를 pytest.fixture로 하나로 묶을 수 없음)
+        fake_user = Members.objects.create(nickname = 'test_b', email = 'testUser1@test.com', is_2fa = False)
+        refresh = RefreshToken.for_user(fake_user)
+        fake_token = str(refresh.access_token)
 
-    fake_game = Game.objects.create(game_option='CLASSIC', game_mode='NORMAL')
+        fake_game = Game.objects.create(game_option='CLASSIC', game_mode='NORMAL')
 
-    test_user = Members.objects.create(nickname = 'tt1', email = 'tt@test.com', is_2fa = False)
-    value = {
-        "registered_user": [{
-            "user_id" : test_user.id,
-            "channel_id": "123"
-        }],
-        "invited_info": [{
-            "user_id": fake_user.id
-        }]
-    }
+        test_user = Members.objects.create(nickname = 'bb', email = 'tt@test.com', is_2fa = False)
+        value = {
+            "registered_user": [{
+                "user_id" : test_user.id,
+                "channel_id": "123"
+            }],
+            "invited_info": [{
+                "user_id": fake_user.id
+            }]
+        }
 
-    #redis에 normal_를 뺀 유효하지 않는 값을 key로하여 저장
-    cache.set(str(fake_game.id),  json.dumps(value))
+        #redis에 normal_를 뺀 유효하지 않는 값을 key로하여 저장
+        cache.set(str(fake_game.id),  json.dumps(value))
 
-    #토큰과 함께 ws/join_queue 에 연결
-    communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + fake_token)
-    communicator.scope = await mock_authenticate(communicator.scope, fake_user)
-    connected, subprotocol = await communicator.connect()
+        #토큰과 함께 ws/join_queue 에 연결
+        communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + fake_token)
+        communicator.scope = await mock_authenticate(communicator.scope, fake_user)
+        connected, subprotocol = await communicator.connect()
 
-    assert connected
+        assert connected
 
-    await communicator.send_json_to({
-        "action": "join_invite_normal_queue",
-        "game_id": fake_game.id
-    })
+        await communicator.send_json_to({
+            "action": "join_invite_normal_queue",
+            "game_id": fake_game.id
+        })
 
-    response = await communicator.receive_json_from()    
+        response = await communicator.receive_json_from()    
 
-    assert response["message"] == "잘못된 game_id 입니다"
+        assert response["message"] == "잘못된 game_id 입니다"
 
-    await communicator.disconnect()
-         
+        await communicator.disconnect()
+
+    finally:
+        fake_user.delete()
+        fake_game.delete()
+        test_user.delete()         
 
 
 #초대리스트에 아무도 없는 경우
 @pytest.mark.asyncio
 async def test_invited_normal_queue_fail_no_invited_info():
 
-    channel_layer = get_channel_layer()
+    try:
+        channel_layer = get_channel_layer()
 
-    # 테스트용 토큰 발급(비동기적으로 실행되기에 테스트용 데이터를 pytest.fixture로 하나로 묶을 수 없음)
-    fake_user = Members.objects.create(nickname = 'test_user2', email = 'testUser1@test.com', is_2fa = False)
-    refresh = RefreshToken.for_user(fake_user)
-    fake_token = str(refresh.access_token)
+        # 테스트용 토큰 발급(비동기적으로 실행되기에 테스트용 데이터를 pytest.fixture로 하나로 묶을 수 없음)
+        fake_user = Members.objects.create(nickname = 'test_c', email = 'testUser1@test.com', is_2fa = False)
+        refresh = RefreshToken.for_user(fake_user)
+        fake_token = str(refresh.access_token)
 
-    fake_game = Game.objects.create(game_option='CLASSIC', game_mode='NORMAL')
+        fake_game = Game.objects.create(game_option='CLASSIC', game_mode='NORMAL')
 
-    test_user = Members.objects.create(nickname = 'tt2', email = 'tt@test.com', is_2fa = False)
+        test_user = Members.objects.create(nickname = 'cc', email = 'tt@test.com', is_2fa = False)
     
-    #초대리스트에 아무것도 없도록 함
-    value = {
-        "registered_user": [{
-            "user_id" : test_user.id,
-            "channel_id": "123"
-        }],
-        "invited_info": []
-    }
+        #초대리스트에 아무것도 없도록 함
+        value = {
+            "registered_user": [{
+                "user_id" : test_user.id,
+                "channel_id": "123"
+            }],
+            "invited_info": []
+        }
 
-    cache.set('normal_' + str(fake_game.id),  json.dumps(value))
+        cache.set('normal_' + str(fake_game.id),  json.dumps(value))
 
-    #토큰과 함께 ws/join_queue 에 연결
-    communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + fake_token)
-    communicator.scope = await mock_authenticate(communicator.scope, fake_user)
-    connected, subprotocol = await communicator.connect()
+        #토큰과 함께 ws/join_queue 에 연결
+        communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + fake_token)
+        communicator.scope = await mock_authenticate(communicator.scope, fake_user)
+        connected, subprotocol = await communicator.connect()
 
-    assert connected
+        assert connected
 
-    await communicator.send_json_to({
-        "action": "join_invite_normal_queue",
-        "game_id": fake_game.id
-    })
+        await communicator.send_json_to({
+            "action": "join_invite_normal_queue",
+            "game_id": fake_game.id
+        })
 
-    response = await communicator.receive_json_from()    
+        response = await communicator.receive_json_from()    
 
-    assert response["message"] == "초대 내역이 없습니다"
+        assert response["message"] == "초대 내역이 없습니다"
 
-    await communicator.disconnect()
+        await communicator.disconnect()
+    
+    finally:
+        fake_user.delete()
+        fake_game.delete()
+        test_user.delete()
          
     
 
 #초대리스트에 user_id가 없는 경우
 @pytest.mark.asyncio
-async def test_invited_normal_queue_fail_invitied_info_no_user_id():
+async def test_invited_normal_queue_fail_invited_info_no_user_id():
 
-    channel_layer = get_channel_layer()
+    try:
+        channel_layer = get_channel_layer()
 
-    # 테스트용 토큰 발급(비동기적으로 실행되기에 테스트용 데이터를 pytest.fixture로 하나로 묶을 수 없음)
-    fake_user = Members.objects.create(nickname = 'test_user3', email = 'testUser1@test.com', is_2fa = False)
-    refresh = RefreshToken.for_user(fake_user)
-    fake_token = str(refresh.access_token)
+        # 테스트용 토큰 발급(비동기적으로 실행되기에 테스트용 데이터를 pytest.fixture로 하나로 묶을 수 없음)
+        fake_user = Members.objects.create(nickname = 'test_d', email = 'testUser1@test.com', is_2fa = False)
+        refresh = RefreshToken.for_user(fake_user)
+        fake_token = str(refresh.access_token)
 
-    fake_game = Game.objects.create(game_option='CLASSIC', game_mode='NORMAL')
+        fake_game = Game.objects.create(game_option='CLASSIC', game_mode='NORMAL')
 
-    test_user = Members.objects.create(nickname = 'tt3', email = 'tt@test.com', is_2fa = False)
-    #초대리스트에 fake_user의 id 대신 유효하지 않은 id 값 저장
-    value = {
-        "registered_user": [{
-            "user_id" : test_user.id,
-            "channel_id": "123"
-        }],
-        "invited_info": [{
-            "user_id": -1,
-        }]
-    }
+        test_user = Members.objects.create(nickname = 'dd', email = 'tt@test.com', is_2fa = False)
 
-    cache.set('normal_' + str(fake_game.id),  json.dumps(value))
+        tmp_user = Members.objects.create(nickname = 'tmp_d', email = "tmp@test.com", is_2fa = False)
 
-    #토큰과 함께 ws/join_queue 에 연결
-    communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + fake_token)
-    communicator.scope = await mock_authenticate(communicator.scope, fake_user)
-    connected, subprotocol = await communicator.connect()
+        #초대리스트에 fake_user의 id 대신 다른 id 값 저장
+        value = {
+            "registered_user": [{
+                "user_id" : test_user.id,
+                "channel_id": "123"
+            }],
+            "invited_info": [{
+                "user_id": tmp_user.id,
+            }]
+        }
 
-    assert connected
+        cache.set('normal_' + str(fake_game.id),  json.dumps(value))
 
-    await communicator.send_json_to({
-        "action": "join_invite_normal_queue",
-        "game_id": fake_game.id
-    })
+        #토큰과 함께 ws/join_queue 에 연결
+        communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + fake_token)
+        communicator.scope = await mock_authenticate(communicator.scope, fake_user)
+        connected, subprotocol = await communicator.connect()
 
-    response = await communicator.receive_json_from()    
+        assert connected
 
-    assert response["message"] == "초대 대상이 아닙니다"
+        await communicator.send_json_to({
+            "action": "join_invite_normal_queue",
+            "game_id": fake_game.id
+        })
 
-    await communicator.disconnect()
+        response = await communicator.receive_json_from()    
+
+        assert response["message"] == "초대 대상이 아닙니다"
+
+        await communicator.disconnect()
+    
+    finally:
+        fake_user.delete()
+        fake_game.delete()
+        test_user.delete()
+        tmp_user.delete()
          
 
 
@@ -211,30 +238,34 @@ async def test_invited_normal_queue_fail_invitied_info_no_user_id():
 @pytest.mark.asyncio
 async def test_invited_normal_queue_success():
 
-    channel_layer = get_channel_layer()
+    try:
+        channel_layer = get_channel_layer()
 
-    # 테스트용 토큰 발급(비동기적으로 실행되기에 테스트용 데이터를 pytest.fixture로 하나로 묶을 수 없음)
-    fake_user = Members.objects.create(nickname = 'test_user', email = 'testUser@test.com', is_2fa = False)
-    refresh = RefreshToken.for_user(fake_user)
-    fake_token = str(refresh.access_token)
+        # 테스트용 토큰 발급(비동기적으로 실행되기에 테스트용 데이터를 pytest.fixture로 하나로 묶을 수 없음)
+        fake_user = Members.objects.create(nickname = 'test_e', email = 'testUser@test.com', is_2fa = False)
+        refresh = RefreshToken.for_user(fake_user)
+        fake_token = str(refresh.access_token)
 
-    #토큰과 함께 ws/join_queue 에 연결
-    communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + fake_token)
-    communicator.scope = await mock_authenticate(communicator.scope, fake_user)
-    connected, subprotocol = await communicator.connect()
+        #토큰과 함께 ws/join_queue 에 연결
+        communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + fake_token)
+        communicator.scope = await mock_authenticate(communicator.scope, fake_user)
+        connected, subprotocol = await communicator.connect()
 
-    assert connected
+        assert connected
 
-    await communicator.send_json_to({
-        "action": "join_invite_normal_queue",
-        "game_id": -1
-    })
+        await communicator.send_json_to({
+            "action": "join_invite_normal_queue",
+            "game_id": -1
+        })
 
-    response = await communicator.receive_json_from()    
+        response = await communicator.receive_json_from()    
 
-    assert response["message"] == "잘못된 game id 입니다"
+        assert response["message"] == "잘못된 game id 입니다"
 
-    await communicator.disconnect()
+        await communicator.disconnect()
+
+    finally:
+        fake_user.delete()
          
 
 
@@ -244,50 +275,56 @@ async def test_invited_normal_queue_success():
 @pytest.mark.asyncio
 async def test_invite_normal_success():
 
-    channel_layer = get_channel_layer()
+    try:
+        channel_layer = get_channel_layer()
 
-    # 테스트용 토큰 발급(비동기적으로 실행되기에 테스트용 데이터를 pytest.fixture로 하나로 묶을 수 없음)
-    fake_user = Members.objects.create(nickname = 'test11', email = 'testUser@test.com', is_2fa = False)
-    refresh = RefreshToken.for_user(fake_user)
-    fake_token = str(refresh.access_token)
+        # 테스트용 토큰 발급(비동기적으로 실행되기에 테스트용 데이터를 pytest.fixture로 하나로 묶을 수 없음)
+        fake_user = Members.objects.create(nickname = 'test_f', email = 'testUser@test.com', is_2fa = False)
+        refresh = RefreshToken.for_user(fake_user)
+        fake_token = str(refresh.access_token)
 
-    test_user = Members.objects.create(nickname = '11', email = 'tt@test.com', is_2fa = False)
-    test_refresh = RefreshToken.for_user(test_user)
-    test_token = str(test_refresh.access_token)
+        test_user = Members.objects.create(nickname = 'ff', email = 'tt@test.com', is_2fa = False)
+        test_refresh = RefreshToken.for_user(test_user)
+        test_token = str(test_refresh.access_token)
 
-    #토큰과 함께 ws/join_queue 에 연결
-    communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + fake_token)
-    communicator.scope = await mock_authenticate(communicator.scope, fake_user)
-    connected, subprotocol = await communicator.connect()
+        #토큰과 함께 ws/join_queue 에 연결
+        communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + fake_token)
+        communicator.scope = await mock_authenticate(communicator.scope, fake_user)
+        connected, subprotocol = await communicator.connect()
 
-    assert connected
+        assert connected
 
-    await communicator.send_json_to({
-        "action": "invite_normal_queue",
-        "game_mode": Game.GameOption.CLASSIC,
-        "invite_user_id": test_user.id
-    })
+        await communicator.send_json_to({
+            "action": "invite_normal_queue",
+            "game_mode": Game.GameOption.CLASSIC,
+            "invite_user_id": test_user.id
+        })
 
-    response = await communicator.receive_json_from()    
+        response = await communicator.receive_json_from()    
 
-    assert response["status"] == "game create success"
+        assert response["status"] == "game create success"
 
-    test_communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + test_token)
-    test_communicator.scope = await mock_authenticate(test_communicator.scope, test_user)
-    test_connected, test_subprotocol = await test_communicator.connect()
+        test_communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + test_token)
+        test_communicator.scope = await mock_authenticate(test_communicator.scope, test_user)
+        test_connected, test_subprotocol = await test_communicator.connect()
 
-    assert test_connected
+        assert test_connected
 
-    await test_communicator.send_json_to({
-        "action": "join_invite_normal_queue",
-        "game_id": response["game_id"]
-    })
+        await test_communicator.send_json_to({
+            "action": "join_invite_normal_queue",
+            "game_id": response["game_id"]
+        })
 
-    response2 = await test_communicator.receive_json_from()    
+        response2 = await test_communicator.receive_json_from()    
 
-    assert response2["status"] == "game_start_soon"
+        assert response2["status"] == "game_start_soon"
 
-    await communicator.disconnect()
+        await communicator.disconnect()
+        await test_communicator.disconnect()
+
+    finally:
+        fake_user.delete()
+        test_user.delete()
 
 
 
@@ -296,31 +333,35 @@ async def test_invite_normal_success():
 @pytest.mark.asyncio
 async def test_invite_normal_invalid_invite_user_id():
 
-    channel_layer = get_channel_layer()
+    try:
+        channel_layer = get_channel_layer()
 
-    # 테스트용 토큰 발급(비동기적으로 실행되기에 테스트용 데이터를 pytest.fixture로 하나로 묶을 수 없음)
-    fake_user = Members.objects.create(nickname = 'test11', email = 'testUser@test.com', is_2fa = False)
-    refresh = RefreshToken.for_user(fake_user)
-    fake_token = str(refresh.access_token)
+        # 테스트용 토큰 발급(비동기적으로 실행되기에 테스트용 데이터를 pytest.fixture로 하나로 묶을 수 없음)
+        fake_user = Members.objects.create(nickname = 'test_g', email = 'testUser@test.com', is_2fa = False)
+        refresh = RefreshToken.for_user(fake_user)
+        fake_token = str(refresh.access_token)
 
-    #토큰과 함께 ws/join_queue 에 연결
-    communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + fake_token)
-    communicator.scope = await mock_authenticate(communicator.scope, fake_user)
-    connected, subprotocol = await communicator.connect()
+        #토큰과 함께 ws/join_queue 에 연결
+        communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + fake_token)
+        communicator.scope = await mock_authenticate(communicator.scope, fake_user)
+        connected, subprotocol = await communicator.connect()
 
-    assert connected
+        assert connected
 
-    await communicator.send_json_to({
-        "action": "invite_normal_queue",
-        "game_mode": Game.GameOption.CLASSIC,
-        "invite_user_id": -1
-    })
+        await communicator.send_json_to({
+            "action": "invite_normal_queue",
+            "game_mode": Game.GameOption.CLASSIC,
+            "invite_user_id": -1
+        })
 
-    response = await communicator.receive_json_from()    
+        response = await communicator.receive_json_from()    
 
-    assert response["message"] == "잘못된 invite user id 입니다"
+        assert response["message"] == "잘못된 invite user id 입니다"
 
-    await communicator.disconnect()
+        await communicator.disconnect()
+
+    finally:
+        fake_user.delete()
 
 
 
@@ -331,47 +372,55 @@ async def test_invite_normal_invalid_invite_user_id():
 @pytest.mark.asyncio
 async def test_join_normal_success():
 
-    channel_layer = get_channel_layer()
+    try:
+        channel_layer = get_channel_layer()
 
-    # 테스트용 토큰 발급(비동기적으로 실행되기에 테스트용 데이터를 pytest.fixture로 하나로 묶을 수 없음)
-    fake_user = Members.objects.create(nickname = 'test12', email = 'testUser@test.com', is_2fa = False)
-    refresh = RefreshToken.for_user(fake_user)
-    fake_token = str(refresh.access_token)
+        # 테스트용 토큰 발급(비동기적으로 실행되기에 테스트용 데이터를 pytest.fixture로 하나로 묶을 수 없음)
+        fake_user = Members.objects.create(nickname = 'test_h', email = 'testUser@test.com', is_2fa = False)
+        refresh = RefreshToken.for_user(fake_user)
+        fake_token = str(refresh.access_token)
 
     
-    test_user = Members.objects.create(nickname = '12', email = 'tt@test.com', is_2fa = False)
-    test_refresh = RefreshToken.for_user(test_user)
-    test_token = str(test_refresh.access_token)
+        test_user = Members.objects.create(nickname = 'hh', email = 'tt@test.com', is_2fa = False)
+        test_refresh = RefreshToken.for_user(test_user)
+        test_token = str(test_refresh.access_token)
 
-    #토큰과 함께 ws/join_queue 에 연결
-    communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + fake_token)
-    communicator.scope = await mock_authenticate(communicator.scope, fake_user)
-    connected, subprotocol = await communicator.connect()
+        #토큰과 함께 ws/join_queue 에 연결
+        communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + fake_token)
+        communicator.scope = await mock_authenticate(communicator.scope, fake_user)
+        connected, subprotocol = await communicator.connect()
 
-    assert connected
+        assert connected
 
-    test_communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + test_token)
-    test_communicator.scope = await mock_authenticate(test_communicator.scope, test_user)
-    test_connected, test_subprotocol = await test_communicator.connect()
+        test_communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + test_token)
+        test_communicator.scope = await mock_authenticate(test_communicator.scope, test_user)
+        test_connected, test_subprotocol = await test_communicator.connect()
 
-    assert test_connected
+        assert test_connected
 
-    await communicator.send_json_to({
-        "action": "join_normal_queue",
-        "game_mode": Game.GameOption.CLASSIC
-    })
+        await communicator.send_json_to({
+            "action": "join_normal_queue",
+            "game_mode": Game.GameOption.CLASSIC
+        })
 
-    await test_communicator.send_json_to({
-        "action": "join_normal_queue",
-        "game_mode": Game.GameOption.CLASSIC
-    })
+        await communicator.receive_json_from()
+
+        await test_communicator.send_json_to({
+            "action": "join_normal_queue",
+            "game_mode": Game.GameOption.CLASSIC
+        })
 
 
-    response = await test_communicator.receive_json_from()    
+        response = await test_communicator.receive_json_from()    
 
-    assert response["status"] == "game_start_soon"
+        assert response["status"] == "game_start_soon"
     
-    await communicator.disconnect()
+        await communicator.disconnect()
+        await test_communicator.disconnect()
+
+    finally:
+        fake_user.delete()
+        test_user.delete()
 
 
 
@@ -382,46 +431,52 @@ async def test_join_normal_success():
 @pytest.mark.asyncio
 async def test_invited_tournament_queue_success():
 
-    channel_layer = get_channel_layer()
+    try:
+        channel_layer = get_channel_layer()
 
-    # 테스트용 토큰 발급(비동기적으로 실행되기에 테스트용 데이터를 pytest.fixture로 하나로 묶을 수 없음)
-    fake_user = Members.objects.create(nickname = 'test111', email = 'testUser@test.com', is_2fa = False)
-    refresh = RefreshToken.for_user(fake_user)
-    fake_token = str(refresh.access_token)
+        # 테스트용 토큰 발급(비동기적으로 실행되기에 테스트용 데이터를 pytest.fixture로 하나로 묶을 수 없음)
+        fake_user = Members.objects.create(nickname = 'test_i', email = 'testUser@test.com', is_2fa = False)
+        refresh = RefreshToken.for_user(fake_user)
+        fake_token = str(refresh.access_token)
 
-    fake_tournament = Tournament.objects.create()
+        fake_tournament = Tournament.objects.create()
 
-    test_user = Members.objects.create(nickname = 'tt111', email = 'tt@test.com', is_2fa = False)
+        test_user = Members.objects.create(nickname = 'tt_i', email = 'tt@test.com', is_2fa = False)
     
-    value = {
-        "registered_user": [{
-            "user_id" : test_user.id,
-            "channel_id": "123"
-        }],
-        "invited_info": [{
-            "user_id": fake_user.id
-        }]
-    }
+        value = {
+            "registered_user": [{
+                "user_id" : test_user.id,
+                "channel_id": "123"
+            }],
+            "invited_info": [{
+                "user_id": fake_user.id
+            }]
+        }
 
-    cache.set('tournament_' + str(fake_tournament.id),  json.dumps(value))
+        cache.set('tournament_' + str(fake_tournament.id),  json.dumps(value))
 
-    #토큰과 함께 ws/join_queue 에 연결
-    communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + fake_token)
-    communicator.scope = await mock_authenticate(communicator.scope, fake_user)
-    connected, subprotocol = await communicator.connect()
+        #토큰과 함께 ws/join_queue 에 연결
+        communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + fake_token)
+        communicator.scope = await mock_authenticate(communicator.scope, fake_user)
+        connected, subprotocol = await communicator.connect()
 
-    assert connected
+        assert connected
 
-    await communicator.send_json_to({
-        "action": "join_invite_tournament_queue",
-        "room_id": fake_tournament.id
-    })
+        await communicator.send_json_to({
+            "action": "join_invite_tournament_queue",
+            "room_id": fake_tournament.id
+        })
 
-    response = await communicator.receive_json_from()    
+        response = await communicator.receive_json_from()    
 
-    assert response["status"] == "success"
+        assert response["status"] == "success"
 
-    await communicator.disconnect()
+        await communicator.disconnect()
+
+    finally:
+        fake_user.delete()
+        fake_tournament.delete()
+        test_user.delete()
 
 
 
@@ -429,47 +484,53 @@ async def test_invited_tournament_queue_success():
 @pytest.mark.asyncio
 async def test_invited_tournament_queue_fail_no_value():
 
-    channel_layer = get_channel_layer()
+    try:
+        channel_layer = get_channel_layer()
 
-    # 테스트용 토큰 발급(비동기적으로 실행되기에 테스트용 데이터를 pytest.fixture로 하나로 묶을 수 없음)
-    fake_user = Members.objects.create(nickname = 'test112', email = 'testUser1@test.com', is_2fa = False)
-    refresh = RefreshToken.for_user(fake_user)
-    fake_token = str(refresh.access_token)
+        # 테스트용 토큰 발급(비동기적으로 실행되기에 테스트용 데이터를 pytest.fixture로 하나로 묶을 수 없음)
+        fake_user = Members.objects.create(nickname = 'test_j', email = 'testUser1@test.com', is_2fa = False)
+        refresh = RefreshToken.for_user(fake_user)
+        fake_token = str(refresh.access_token)
 
-    fake_tournament = Tournament.objects.create()
+        fake_tournament = Tournament.objects.create()
 
-    test_user = Members.objects.create(nickname = 'tt112', email = 'tt@test.com', is_2fa = False)
+        test_user = Members.objects.create(nickname = 'tt_j', email = 'tt@test.com', is_2fa = False)
     
-    value = {
-        "registered_user": [{
-            "user_id" : test_user.id,
-            "channel_id": "123"
-        }],
-        "invited_info": [{
-            "user_id": fake_user.id
-        }]
-    }
+        value = {
+            "registered_user": [{
+                "user_id" : test_user.id,
+                "channel_id": "123"
+            }],
+            "invited_info": [{
+                "user_id": fake_user.id
+            }]
+        }
 
-    #redis에 tournament_를 뺀 유효하지 않는 값을 key로하여 저장
-    cache.set(str(fake_tournament.id),  json.dumps(value))
+        #redis에 tournament_를 뺀 유효하지 않는 값을 key로하여 저장
+        cache.set(str(fake_tournament.id),  json.dumps(value))
 
-    #토큰과 함께 ws/join_queue 에 연결
-    communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + fake_token)
-    communicator.scope = await mock_authenticate(communicator.scope, fake_user)
-    connected, subprotocol = await communicator.connect()
+        #토큰과 함께 ws/join_queue 에 연결
+        communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + fake_token)
+        communicator.scope = await mock_authenticate(communicator.scope, fake_user)
+        connected, subprotocol = await communicator.connect()
 
-    assert connected
+        assert connected
 
-    await communicator.send_json_to({
-        "action": "join_invite_tournament_queue",
-        "room_id": fake_tournament.id
-    })
+        await communicator.send_json_to({
+            "action": "join_invite_tournament_queue",
+            "room_id": fake_tournament.id
+        })
 
-    response = await communicator.receive_json_from()    
+        response = await communicator.receive_json_from()    
 
-    assert response["message"] == "잘못된 room_id 입니다"
+        assert response["message"] == "잘못된 room_id 입니다"
 
-    await communicator.disconnect()
+        await communicator.disconnect()
+
+    finally:
+        fake_user.delete()
+        fake_tournament.delete()
+        test_user.delete()
     
 
 
@@ -477,92 +538,108 @@ async def test_invited_tournament_queue_fail_no_value():
 @pytest.mark.asyncio
 async def test_invited_tournament_queue_fail_no_invited_info():
 
-    channel_layer = get_channel_layer()
+    try:
+        channel_layer = get_channel_layer()
 
-    # 테스트용 토큰 발급(비동기적으로 실행되기에 테스트용 데이터를 pytest.fixture로 하나로 묶을 수 없음)
-    fake_user = Members.objects.create(nickname = 'test113', email = 'testUser1@test.com', is_2fa = False)
-    refresh = RefreshToken.for_user(fake_user)
-    fake_token = str(refresh.access_token)
+        # 테스트용 토큰 발급(비동기적으로 실행되기에 테스트용 데이터를 pytest.fixture로 하나로 묶을 수 없음)
+        fake_user = Members.objects.create(nickname = 'test_k', email = 'testUser1@test.com', is_2fa = False)
+        refresh = RefreshToken.for_user(fake_user)
+        fake_token = str(refresh.access_token)
 
-    fake_tournament = Tournament.objects.create()
+        fake_tournament = Tournament.objects.create()
 
-    test_user = Members.objects.create(nickname = 'tt113', email = 'tt@test.com', is_2fa = False)
+        test_user = Members.objects.create(nickname = 'tt_k', email = 'tt@test.com', is_2fa = False)
     
-    #초대리스트에 아무것도 없도록 함
-    value = {
-        "registered_user": [{
-            "user_id" : test_user.id,
-            "channel_id": "123"
-        }],
-        "invited_info": []
-    }
+        #초대리스트에 아무것도 없도록 함
+        value = {
+            "registered_user": [{
+                "user_id" : test_user.id,
+                "channel_id": "123"
+            }],
+            "invited_info": []
+        }
 
-    cache.set('tournament_' + str(fake_tournament.id),  json.dumps(value))
+        cache.set('tournament_' + str(fake_tournament.id),  json.dumps(value))
 
-    #토큰과 함께 ws/join_queue 에 연결
-    communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + fake_token)
-    communicator.scope = await mock_authenticate(communicator.scope, fake_user)
-    connected, subprotocol = await communicator.connect()
+        #토큰과 함께 ws/join_queue 에 연결
+        communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + fake_token)
+        communicator.scope = await mock_authenticate(communicator.scope, fake_user)
+        connected, subprotocol = await communicator.connect()
 
-    assert connected
+        assert connected
 
-    await communicator.send_json_to({
-        "action": "join_invite_tournament_queue",
-        "room_id": fake_tournament.id
-    })
+        await communicator.send_json_to({
+            "action": "join_invite_tournament_queue",
+            "room_id": fake_tournament.id
+        })
 
-    response = await communicator.receive_json_from()    
+        response = await communicator.receive_json_from()    
 
-    assert response["message"] == "초대 내역이 없습니다"
+        assert response["message"] == "초대 내역이 없습니다"
 
-    await communicator.disconnect()
+        await communicator.disconnect()
+
+    finally:
+        fake_user.delete()
+        fake_tournament.delete()
+        test_user.delete()
 
 
 
 #초대리스트에 user_id가 없는 경우
 @pytest.mark.asyncio
-async def test_invited_tournament_queue_fail_invitied_info_no_user_id():
+async def test_invited_tournament_queue_fail_invited_info_no_user_id():
 
-    channel_layer = get_channel_layer()
+    try:
+        channel_layer = get_channel_layer()
 
-    # 테스트용 토큰 발급(비동기적으로 실행되기에 테스트용 데이터를 pytest.fixture로 하나로 묶을 수 없음)
-    fake_user = Members.objects.create(nickname = 'test114', email = 'testUser1@test.com', is_2fa = False)
-    refresh = RefreshToken.for_user(fake_user)
-    fake_token = str(refresh.access_token)
+        # 테스트용 토큰 발급(비동기적으로 실행되기에 테스트용 데이터를 pytest.fixture로 하나로 묶을 수 없음)
+        fake_user = Members.objects.create(nickname = 'test_l', email = 'testUser1@test.com', is_2fa = False)
+        refresh = RefreshToken.for_user(fake_user)
+        fake_token = str(refresh.access_token)
 
-    fake_tournament = Tournament.objects.create()
+        fake_tournament = Tournament.objects.create()
 
-    test_user = Members.objects.create(nickname = 'tt114', email = 'tt@test.com', is_2fa = False)
-    #초대리스트에 fake_user의 id 대신 유효하지 않은 id 값 저장
-    value = {
-        "registered_user": [{
-            "user_id" : test_user.id,
-            "channel_id": "123"
-        }],
-        "invited_info": [{
-            "user_id": -1
-        }]
-    }
+        test_user = Members.objects.create(nickname = 'tt_l', email = 'tt@test.com', is_2fa = False)
+        
+        tmp_user = Members.objects.create(nickname = 'tmp_l', email = 'tmp@test.com', is_2fa = False)
+        #초대리스트에 fake_user의 id 대신 다른 id 값 저장
+        value = {
+            "registered_user": [{
+                "user_id" : test_user.id,
+                "channel_id": "123"
+            }],
+            "invited_info": [{
+                "user_id": tmp_user.id
+            }]
+        }
 
-    cache.set('tournament_' + str(fake_tournament.id),  json.dumps(value))
+        cache.set('tournament_' + str(fake_tournament.id),  json.dumps(value))
 
-    #토큰과 함께 ws/join_queue 에 연결
-    communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + fake_token)
-    communicator.scope = await mock_authenticate(communicator.scope, fake_user)
-    connected, subprotocol = await communicator.connect()
+        #토큰과 함께 ws/join_queue 에 연결
+        communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + fake_token)
+        communicator.scope = await mock_authenticate(communicator.scope, fake_user)
+        connected, subprotocol = await communicator.connect()
 
-    assert connected
+        assert connected
 
-    await communicator.send_json_to({
-        "action": "join_invite_tournament_queue",
-        "room_id": fake_tournament.id
-    })
+        await communicator.send_json_to({
+            "action": "join_invite_tournament_queue",
+            "room_id": fake_tournament.id
+        })
 
-    response = await communicator.receive_json_from()    
+        response = await communicator.receive_json_from()    
 
-    assert response["message"] == "초대 대상이 아닙니다"
+        assert response["message"] == "초대 대상이 아닙니다"
 
-    await communicator.disconnect()
+        await communicator.disconnect()
+
+    finally:
+        fake_user.delete()
+        fake_tournament.delete()
+        test_user.delete()
+        tmp_user.delete()
+
     
 
 
@@ -571,31 +648,35 @@ async def test_invited_tournament_queue_fail_invitied_info_no_user_id():
 @pytest.mark.asyncio
 async def test_invited_tournament_queue_invalid_tournament_id():
 
-    channel_layer = get_channel_layer()
+    try:
+        channel_layer = get_channel_layer()
 
-    # 테스트용 토큰 발급(비동기적으로 실행되기에 테스트용 데이터를 pytest.fixture로 하나로 묶을 수 없음)
-    fake_user = Members.objects.create(nickname = 'test111', email = 'testUser@test.com', is_2fa = False)
-    refresh = RefreshToken.for_user(fake_user)
-    fake_token = str(refresh.access_token)
+        # 테스트용 토큰 발급(비동기적으로 실행되기에 테스트용 데이터를 pytest.fixture로 하나로 묶을 수 없음)
+        fake_user = Members.objects.create(nickname = 'test_m', email = 'testUser@test.com', is_2fa = False)
+        refresh = RefreshToken.for_user(fake_user)
+        fake_token = str(refresh.access_token)
 
     
-    #토큰과 함께 ws/join_queue 에 연결
-    communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + fake_token)
-    communicator.scope = await mock_authenticate(communicator.scope, fake_user)
-    connected, subprotocol = await communicator.connect()
+        #토큰과 함께 ws/join_queue 에 연결
+        communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + fake_token)
+        communicator.scope = await mock_authenticate(communicator.scope, fake_user)
+        connected, subprotocol = await communicator.connect()
 
-    assert connected
+        assert connected
 
-    await communicator.send_json_to({
-        "action": "join_invite_tournament_queue",
-        "room_id": -1
-    })
+        await communicator.send_json_to({
+            "action": "join_invite_tournament_queue",
+            "room_id": -1
+        })
 
-    response = await communicator.receive_json_from()    
+        response = await communicator.receive_json_from()    
 
-    assert response["message"] == "잘못된 room_id 입니다"
+        assert response["message"] == "잘못된 room_id 입니다"
 
-    await communicator.disconnect()
+        await communicator.disconnect()
+
+    finally:
+        fake_user.delete()
 
 
 
@@ -606,32 +687,37 @@ async def test_invited_tournament_queue_invalid_tournament_id():
 @pytest.mark.asyncio
 async def test_invite_tournament_success():
 
-    channel_layer = get_channel_layer()
+    try:
+        channel_layer = get_channel_layer()
 
-    # 테스트용 토큰 발급(비동기적으로 실행되기에 테스트용 데이터를 pytest.fixture로 하나로 묶을 수 없음)
-    fake_user = Members.objects.create(nickname = 'test1111', email = 'testUser@test.com', is_2fa = False)
-    refresh = RefreshToken.for_user(fake_user)
-    fake_token = str(refresh.access_token)
+        # 테스트용 토큰 발급(비동기적으로 실행되기에 테스트용 데이터를 pytest.fixture로 하나로 묶을 수 없음)
+        fake_user = Members.objects.create(nickname = 'test_n', email = 'testUser@test.com', is_2fa = False)
+        refresh = RefreshToken.for_user(fake_user)
+        fake_token = str(refresh.access_token)
 
-    test_user = Members.objects.create(nickname = '1111', email = 'tt@test.com', is_2fa = False)
+        test_user = Members.objects.create(nickname = 'n', email = 'tt@test.com', is_2fa = False)
     
-    #토큰과 함께 ws/join_queue 에 연결
-    communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + fake_token)
-    communicator.scope = await mock_authenticate(communicator.scope, fake_user)
-    connected, subprotocol = await communicator.connect()
+        #토큰과 함께 ws/join_queue 에 연결
+        communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + fake_token)
+        communicator.scope = await mock_authenticate(communicator.scope, fake_user)
+        connected, subprotocol = await communicator.connect()
 
-    assert connected
+        assert connected
 
-    await communicator.send_json_to({
-        "action": "invite_tournament_queue",
-        "invite_user_id": test_user.id
-    })
+        await communicator.send_json_to({
+            "action": "invite_tournament_queue",
+            "invite_user_id": test_user.id
+        })
 
-    response = await communicator.receive_json_from()    
+        response = await communicator.receive_json_from()    
 
-    assert response["status"] == "game create success"
+        assert response["status"] == "game create success"
 
-    await communicator.disconnect()
+        await communicator.disconnect()
+
+    finally:
+        fake_user.delete()
+        test_user.delete()
 
 
 
@@ -640,30 +726,34 @@ async def test_invite_tournament_success():
 @pytest.mark.asyncio
 async def test_invite_tournament_invalid_invite_user_id():
 
-    channel_layer = get_channel_layer()
+    try:
+        channel_layer = get_channel_layer()
 
-    # 테스트용 토큰 발급(비동기적으로 실행되기에 테스트용 데이터를 pytest.fixture로 하나로 묶을 수 없음)
-    fake_user = Members.objects.create(nickname = 'test1111', email = 'testUser@test.com', is_2fa = False)
-    refresh = RefreshToken.for_user(fake_user)
-    fake_token = str(refresh.access_token)
+        # 테스트용 토큰 발급(비동기적으로 실행되기에 테스트용 데이터를 pytest.fixture로 하나로 묶을 수 없음)
+        fake_user = Members.objects.create(nickname = 'test_o', email = 'testUser@test.com', is_2fa = False)
+        refresh = RefreshToken.for_user(fake_user)
+        fake_token = str(refresh.access_token)
 
-    #토큰과 함께 ws/join_queue 에 연결
-    communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + fake_token)
-    communicator.scope = await mock_authenticate(communicator.scope, fake_user)
-    connected, subprotocol = await communicator.connect()
+        #토큰과 함께 ws/join_queue 에 연결
+        communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + fake_token)
+        communicator.scope = await mock_authenticate(communicator.scope, fake_user)
+        connected, subprotocol = await communicator.connect()
 
-    assert connected
+        assert connected
 
-    await communicator.send_json_to({
-        "action": "invite_tournament_queue",
-        "invite_user_id": -1
-    })
+        await communicator.send_json_to({
+            "action": "invite_tournament_queue",
+            "invite_user_id": -1
+        })
 
-    response = await communicator.receive_json_from()    
+        response = await communicator.receive_json_from()    
 
-    assert response["message"] == "잘못된 invite user id 입니다"
+        assert response["message"] == "잘못된 invite user id 입니다"
 
-    await communicator.disconnect()
+        await communicator.disconnect()
+
+    finally:
+        fake_user.delete()
 
 
 
@@ -673,33 +763,35 @@ async def test_invite_tournament_invalid_invite_user_id():
 @pytest.mark.asyncio
 async def test_join_tournament_success():
 
-    channel_layer = get_channel_layer()
+    try:
+        channel_layer = get_channel_layer()
 
-    # 테스트용 토큰 발급(비동기적으로 실행되기에 테스트용 데이터를 pytest.fixture로 하나로 묶을 수 없음)
-    fake_user = Members.objects.create(nickname = 't11111', email = 'testUser@test.com', is_2fa = False)
-    refresh = RefreshToken.for_user(fake_user)
-    fake_token = str(refresh.access_token)
+        # 테스트용 토큰 발급(비동기적으로 실행되기에 테스트용 데이터를 pytest.fixture로 하나로 묶을 수 없음)
+        fake_user = Members.objects.create(nickname = 'test_p', email = 'testUser@test.com', is_2fa = False)
+        refresh = RefreshToken.for_user(fake_user)
+        fake_token = str(refresh.access_token)
 
-    test_user = Members.objects.create(nickname = '11111', email = 'tt@test.com', is_2fa = False)
     
-    #토큰과 함께 ws/join_queue 에 연결
-    communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + fake_token)
-    communicator.scope = await mock_authenticate(communicator.scope, fake_user)
-    connected, subprotocol = await communicator.connect()
+        #토큰과 함께 ws/join_queue 에 연결
+        communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + fake_token)
+        communicator.scope = await mock_authenticate(communicator.scope, fake_user)
+        connected, subprotocol = await communicator.connect()
 
-    assert connected
+        assert connected
 
-    await communicator.send_json_to({
-        "action": "join_tournament_queue"
-    })
+        await communicator.send_json_to({
+            "action": "join_tournament_queue"
+        })
 
 
-    response = await communicator.receive_json_from()    
+        response = await communicator.receive_json_from()    
 
-    assert response["status"] == "success"
+        assert response["status"] == "success"
     
-    await communicator.disconnect()
+        await communicator.disconnect()
 
+    finally:
+        fake_user.delete()
 
 
 #-------------------------------------------------------------------------------
@@ -708,26 +800,30 @@ async def test_join_tournament_success():
 @pytest.mark.asyncio
 async def test_invalid_action():
 
-    channel_layer = get_channel_layer()
+    try:
+        channel_layer = get_channel_layer()
 
-    # 테스트용 토큰 발급(비동기적으로 실행되기에 테스트용 데이터를 pytest.fixture로 하나로 묶을 수 없음)
-    fake_user = Members.objects.create(nickname = 't11111', email = 'testUser@test.com', is_2fa = False)
-    refresh = RefreshToken.for_user(fake_user)
-    fake_token = str(refresh.access_token)
+        # 테스트용 토큰 발급(비동기적으로 실행되기에 테스트용 데이터를 pytest.fixture로 하나로 묶을 수 없음)
+        fake_user = Members.objects.create(nickname = 'test_q', email = 'testUser@test.com', is_2fa = False)
+        refresh = RefreshToken.for_user(fake_user)
+        fake_token = str(refresh.access_token)
 
-    #토큰과 함께 ws/join_queue 에 연결
-    communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + fake_token)
-    communicator.scope = await mock_authenticate(communicator.scope, fake_user)
-    connected, subprotocol = await communicator.connect()
+     #토큰과 함께 ws/join_queue 에 연결
+        communicator = WebsocketCommunicator(GameQueueConsumer.as_asgi(), "/ws/join_queue?token=" + fake_token)
+        communicator.scope = await mock_authenticate(communicator.scope, fake_user)
+        connected, subprotocol = await communicator.connect()
 
-    assert connected
+        assert connected
 
-    await communicator.send_json_to({
-        "action": "invalid"
-    })
+        await communicator.send_json_to({
+            "action": "invalid"
+        })
 
-    response = await communicator.receive_json_from()    
+        response = await communicator.receive_json_from()    
 
-    assert response["message"] == "잘못된 action 입니다"
+        assert response["message"] == "잘못된 action 입니다"
     
-    await communicator.disconnect()
+        await communicator.disconnect()
+
+    finally:
+        fake_user.delete()


### PR DESCRIPTION
## ✅ PR 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 수정
- [ ] 기능에 영향을 주지 않는 변경사항
- [ ] 기능 향상
- [ ] 파일 or 폴더명 수정
- [ ] 파일 or 폴더 삭제

## 📰 관련 이슈
<!---- 아래에 주소에 이슈번호를 넣어주세요! ---->
<!---- ex) https://github.com/42EASY/PongPongPingPong/issues/1 ---->
- https://github.com/42EASY/PongPongPingPong/issues/171

## 📝 PR 내용
<!---- 해당 PR에 어떤 작업을 하였는지 설명해주세요. ---->

normal, tournament 빠른 시작시에 오류 발생
- registered_user에 지워진 데이터가 남아있어서, 이를 참조하는 과정에서 db 오류 발생하는 부분 해결
- normal 인 경우 registered_user에 2명이 들어가야하는데, 3명이 들어가는 오류 발생하는 부분 해결

테스트코드 실행 후에 더미 데이터가 계속 남아있는 현상 발생하여, 이를 수정
