### PR TITLE
fix: refresh token 관련 버그 픽스

### DIFF
--- a/backend/transcendence/security/auth_views.py
+++ b/backend/transcendence/security/auth_views.py
@@ -68,7 +68,7 @@ class LoginView(APIView):
 
 		refresh_token_lifetime = int(settings.SIMPLE_JWT['REFRESH_TOKEN_LIFETIME'].total_seconds())
 
-		cache.set(refresh_token, member.id, timeout=refresh_token_lifetime)
+		cache.set(f"refresh_token:{member.id}", refresh_token, timeout=refresh_token_lifetime)
 
 		res = JsonResponse({
 			'code': 201 if created else 200,
@@ -103,7 +103,7 @@ class LogoutView(APIView):
 				'result':{}
 			}, status=200)
 
-			res.delete_cookie('refresh_token')
+			res.delete_cookie('refresh_token', path='/')
 
 			return res
 		except Members.DoesNotExist:

--- a/frontend/src/state/State.js
+++ b/frontend/src/state/State.js
@@ -120,6 +120,7 @@ const logout = () => {
       "content-Type": "application/json",
       Authorization: `Bearer ${getAccessToken()}`,
     },
+    credentials: "include",
   })
     .then((res) => res.json())
     .then((data) => {


### PR DESCRIPTION
## ✅ PR 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 수정
- [ ] 기능에 영향을 주지 않는 변경사항
- [ ] 기능 향상
- [ ] 파일 or 폴더명 수정
- [ ] 파일 or 폴더 삭제

## 📰 관련 이슈
<!---- 아래에 주소에 이슈번호를 넣어주세요! ---->
<!---- ex) https://github.com/42EASY/PongPongPingPong/issues/1 ---->
- https://github.com/42EASY/PongPongPingPong/issues/200

## 📝 PR 내용
<!---- 해당 PR에 어떤 작업을 하였는지 설명해주세요. ---->
- refresh token이 redis에 제대로 저장되지 않는 문제를 해결했습니다.
- 프론트엔드에서 쿠키를 포함시켜 logout 요청을 보내도록 설정해줬습니다.
