### PR TITLE
fix: 토스트 순서 변경 및 채팅 기능 향상

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -24,13 +24,13 @@
     />
     <link rel="stylesheet" href="/src/styles/nav.css" />
     <link rel="stylesheet" href="/src/styles/modal.css" />
-    <link rel="stylesheet" href="/src/styles/sidebar.css" />
     <link rel="stylesheet" href="/src/styles/toast.css" />
+    <link rel="stylesheet" href="/src/styles/sidebar.css" />
   </head>
   <body>
     <nav class="nav"></nav>
-    <nav class="sidebar"></nav>
     <nav class="toast"></nav>
+    <nav class="sidebar"></nav>
     <main class="App"></main>
     <script type="module" src="/src/App.js"></script>
   </body>

--- a/frontend/src/components/Chat/Chat.js
+++ b/frontend/src/components/Chat/Chat.js
@@ -9,6 +9,8 @@ export default function Chat(user, cnt, roomName) {
   const $chatWrapper = document.createElement("div");
   $chatWrapper.classList.add("chatWrapper");
 
+  $chatWrapper.setAttribute("roomName", roomName);
+  
   const $profileInfo = document.createElement("div");
   $profileInfo.classList.add("profileInfo");
 

--- a/frontend/src/components/Chat/ChatRoom/BotContent.js
+++ b/frontend/src/components/Chat/ChatRoom/BotContent.js
@@ -27,7 +27,7 @@ export default function BotContent(data) {
 
   const $botContentTime = document.createElement("div");
   $botContentTime.classList.add("chatContentTime");
-  $botContentTime.innerHTML = formatTimestamp();
+  $botContentTime.innerHTML = formatTimestamp(data.timestamp);
 
   const $botContentBox = document.createElement("div");
 

--- a/frontend/src/pages/BotRoom.js
+++ b/frontend/src/pages/BotRoom.js
@@ -1,9 +1,10 @@
-import WebSocketManager from "../state/WebSocketManager.js";
+import ChatSocketManager from "../state/ChatSocketManager.js";
 import BotContent from "../components/Chat/ChatRoom/BotContent.js";
 import ChatInput from "../components/Chat/ChatRoom/ChatInput.js";
 import Title from "../components/Chat/Title.js";
+import { getUserId } from "../state/State.js";
 
-const socket = WebSocketManager.getInstance();
+const socket = ChatSocketManager.getInstance();
 
 export default function BotRoom() {
   const $botRoomWrapper = document.querySelector(".sidebarArea");
@@ -27,24 +28,26 @@ export default function BotRoom() {
 
   socket.send(
     JSON.stringify({
-      action: "",
+      action: "fetch_bot_notify_messages",
+      user_id: getUserId(),
     })
   );
+
   socket.onmessage = (e) => {
     const data = JSON.parse(e.data);
-    // todo: fetch messages
-    if (data.action === "") {
-      for (const message of data.messages)
+
+    if (data.action === "fetch_bot_notify_messages") {
+      for (const message of data.data) {
         $botContentsWrapper.appendChild(BotContent(message));
+      }
       $botRoomWrapper.scrollTop = $botRoomWrapper.scrollHeight;
-    } else if (data.action !== "fail") {
+    } else if (
+      data.action === "bot_notify_tournament_game_result" ||
+      data.action === "bot_notify_invited_normal_game" ||
+      data.action === "bot_notify_invited_tournament_game" ||
+      data.action === "bot_notify_tournament_game_opponent"
+    ) {
       $botContentsWrapper.appendChild(BotContent(data));
-      // todo: send - update_read_time
-      socket.send(
-        JSON.stringify({
-          action: "",
-        })
-      );
       $botRoomWrapper.scrollTop = $botRoomWrapper.scrollHeight;
     }
   };

--- a/frontend/src/pages/Chat.js
+++ b/frontend/src/pages/Chat.js
@@ -3,6 +3,7 @@ import ChatSocketManager from "../state/ChatSocketManager.js";
 import ChatRoom from "../components/Chat/Chat.js";
 import NoChat from "../components/Chat/NoChat.js";
 import Bot from "../components/Chat/Bot.js";
+import { createRoomName } from "./ChatRoom.js"
 
 function fetchChats(data) {
   const $chatRoomListWrapper = document.querySelector(".chatRoomListWrapper");
@@ -20,6 +21,23 @@ function fetchChats(data) {
       const $chat = ChatRoom(user, cnt, roomName);
       $chatRoomListWrapper.appendChild($chat);
     }
+  }
+}
+
+function updateUnreadMessageCount(user, roomName) {
+  // 채팅방 요소 선택
+  const chatRoomElement = document.querySelector(`[roomName="${roomName}"]`);
+  if (chatRoomElement) {
+    const unreadCountElement = chatRoomElement.querySelector('.chatStatus');
+    if (unreadCountElement) {
+      let currentCount = parseInt(unreadCountElement.textContent, 10) || 0;
+      unreadCountElement.textContent = currentCount + 1; // 안 읽은 메시지 수 증가
+    }
+  } else {
+    // 채팅방이 존재하지 않는 경우, 새로운 채팅방을 생성하여 추가
+    const $chatRoomListWrapper = document.querySelector(".chatRoomListWrapper");
+    const $chat = ChatRoom(user, 1, roomName); // 새 채팅방 생성
+    $chatRoomListWrapper.appendChild($chat); // 채팅방 목록에 추가
   }
 }
 
@@ -57,6 +75,13 @@ export default function Chat() {
     if (data.action === "fetch_chat_list") {
       const list = data.data;
       fetchChats(list);
+    } 
+    if (data.action === "receive_message") {
+      const sender = data.sender;
+      const receiver = data.receiver;
+      const roomName = createRoomName(receiver.user_id, sender.user_id);
+
+      updateUnreadMessageCount(sender, roomName);
     }
   };
 

--- a/frontend/src/pages/ChatRoom.js
+++ b/frontend/src/pages/ChatRoom.js
@@ -9,7 +9,7 @@ import { getTimestamp } from "../state/ChatState.js";
 
 const socket = ChatSocketManager.getInstance();
 
-function createRoomName(meId, userId) {
+export function createRoomName(meId, userId) {
   const roomName = `chat_${Math.min(meId, userId)}_${Math.max(meId, userId)}`;
   return roomName;
 }

--- a/frontend/src/state/WebSocketManager.js
+++ b/frontend/src/state/WebSocketManager.js
@@ -42,6 +42,9 @@ var WebSocketManager = (function () {
               console.log(data);
               showToast('새로운 채팅이 왔습니다.');
             }
+            if (data.action === 'bot_notify') {
+                showToast('새로운 알림이 왔습니다.');
+            }
             if (data.action === 'notify_chat_partner_status') {
                 console.log(data);
                 const userId = data.partner_id;

--- a/frontend/src/styles/toast.css
+++ b/frontend/src/styles/toast.css
@@ -22,7 +22,7 @@
 	border-radius: 8px;
 
 	text-align: center;
-	z-index: 10;
+	z-index: 1050;
     left: 50%;
     transform: translateX(-50%); /* 가운데 정렬을 위해 수정 */
     top: 50px;


### PR DESCRIPTION
## ✅ PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 수정
- [ ] 기능에 영향을 주지 않는 변경사항
- [ ] 기능 향상
- [ ] 파일 or 폴더명 수정
- [ ] 파일 or 폴더 삭제

## 📰 관련 이슈
<!---- 아래에 주소에 이슈번호를 넣어주세요! ---->
<!---- ex) https://github.com/42EASY/PongPongPingPong/issues/1 ---->
- https://github.com/42EASY/PongPongPingPong/issues/208

## 📝 PR 내용
<!---- 해당 PR에 어떤 작업을 하였는지 설명해주세요. ---->
- 토스트(알림)을 사이드바보다 상단에 위치하도록 변경했습니다.
- 타임스탬프 포맷을 변경했습니다.
- 봇 알림이 오면 "새로운 알림이 있습니다"라는 토스트가 뜨도록 기능을 구현했습니다.
- 봇 채팅방 입장 시 현재까지의 알림을 받아오는 기능을 구현했습니다.
- 채팅 목록에 있을 때 실시간으로 메세지 카운트를 바꿀 수 있도록 했습니다.
