### PR TITLE
FIX: 토너먼트 id 반환 부분 수정 및 redis host 변경 등 세부 사항 변경

### DIFF
--- a/backend/transcendence/games/distributed_lock.py
+++ b/backend/transcendence/games/distributed_lock.py
@@ -4,8 +4,7 @@ import redis
 class DistributedLock:
     def __init__(self):
         self.lock_key = "lock:game_queue"
-        #TODO: host 변경하기
-        self.redis_conn = redis.StrictRedis(host='localhost', port=6379, db=0)
+        self.redis_conn = redis.StrictRedis(host='redis', port=6379, db=0)
         self.acquire_timeout = 10
         
     def acquire_lock(self):

--- a/backend/transcendence/games/game_room_consumer.py
+++ b/backend/transcendence/games/game_room_consumer.py
@@ -394,8 +394,6 @@ class GameRoomConsumer(AsyncJsonWebsocketConsumer):
 
         #만일 4명이 방에 다 들어오면 방에 있는 모두에게 게임 시작 알림
         if (len(new_parsed_value["join_user"]) == 4):
-            #잠시 5초동안 정지
-            time.sleep(5)
 
             matching_value = []
 

--- a/backend/transcendence/games/game_room_consumer.py
+++ b/backend/transcendence/games/game_room_consumer.py
@@ -466,6 +466,7 @@ class GameRoomConsumer(AsyncJsonWebsocketConsumer):
                 sorted_matching_value[0]["channel_id"],
                 {
                     'type': 'broadcast_game_start',
+                    'status': 'semi_final_game_start_soon',
                     'game_id': game1.id,
                     'player_info': {
                         "user_id": sorted_matching_value[1]["user_id"],
@@ -480,6 +481,7 @@ class GameRoomConsumer(AsyncJsonWebsocketConsumer):
                 sorted_matching_value[1]["channel_id"],
                 {
                     'type': 'broadcast_game_start',
+                    'status': 'semi_final_game_start_soon',
                     'game_id': game1.id,
                     'player_info': {
                         "user_id": sorted_matching_value[0]["user_id"],
@@ -494,6 +496,7 @@ class GameRoomConsumer(AsyncJsonWebsocketConsumer):
                 sorted_matching_value[2]["channel_id"],
                 {
                     'type': 'broadcast_game_start',
+                    'status': 'semi_final_game_start_soon',
                     'game_id': game2.id,
                     'player_info': {
                         "user_id": sorted_matching_value[3]["user_id"],
@@ -507,6 +510,7 @@ class GameRoomConsumer(AsyncJsonWebsocketConsumer):
                 sorted_matching_value[3]["channel_id"],
                 {
                     'type': 'broadcast_game_start',
+                    'status': 'semi_final_game_start_soon',
                     'game_id': game2.id,
                     'player_info': {
                         "user_id": sorted_matching_value[2]["user_id"],
@@ -682,6 +686,7 @@ class GameRoomConsumer(AsyncJsonWebsocketConsumer):
                 matching_value[0]["channel_id"],
                 {
                     'type': 'broadcast_game_start',
+                    'status': 'final_game_start_soon',
                     'game_id': game.id,
                     'player_info': {
                         "user_id": matching_value[1]["user_id"],
@@ -696,6 +701,7 @@ class GameRoomConsumer(AsyncJsonWebsocketConsumer):
                 matching_value[1]["channel_id"],
                 {
                     'type': 'broadcast_game_start',
+                    'status': 'final_game_start_soon',
                     'game_id': game.id,
                     'player_info': {
                         "user_id": matching_value[0]["user_id"],
@@ -709,9 +715,10 @@ class GameRoomConsumer(AsyncJsonWebsocketConsumer):
     async def broadcast_game_start(self, event):
         game_id = event["game_id"]
         player_info = event["player_info"]
+        status = event["status"]
 
         await self.send_json({
-            "status": "game_start_soon",
+            "status": status,
             "game_id": game_id,
             "player_info": player_info
         })

--- a/backend/transcendence/games/game_room_consumer.py
+++ b/backend/transcendence/games/game_room_consumer.py
@@ -239,7 +239,7 @@ class GameRoomConsumer(AsyncJsonWebsocketConsumer):
         
         await self.send_json({
                 'status': 'invitation list registered',
-                'tournament_id': self.room_id
+                'room_id': self.room_id
             })
         
 

--- a/backend/transcendence/games/test_game_room_consumer.py
+++ b/backend/transcendence/games/test_game_room_consumer.py
@@ -66,9 +66,11 @@ async def test_join_room_success():
             "action": "join_room"
         })
 
+        await communicator.receive_json_from() 
+
         response = await communicator.receive_json_from()    
 
-        assert response["status"] == "game_start_soon"
+        assert response["status"] == "semi_final_game_start_soon"
 
         await communicator.disconnect()
 
@@ -171,10 +173,11 @@ async def test_invite_and_join_room_success():
         
         join_response = await join_communicator.receive_json_from()    
        
+        await invite_communicator.receive_json_from()  
 
         invite_response = await invite_communicator.receive_json_from()  
 
-        assert invite_response["status"] == "game_start_soon"
+        assert invite_response["status"] == "semi_final_game_start_soon"
         
         await invite_communicator.disconnect()
         await join_communicator.disconnect()
@@ -248,7 +251,7 @@ async def test_join_final_room_success():
 
         response = await communicator.receive_json_from()    
 
-        assert response["status"] == "game_start_soon"
+        assert response["status"] == "final_game_start_soon"
 
         await communicator.disconnect()
 
@@ -392,7 +395,7 @@ async def test_join_final_room_disconnect():
 
         response = await communicator.receive_json_from()    
 
-        assert response["status"] == "game_start_soon"
+        assert response["status"] == "final_game_start_soon"
 
         await communicator.disconnect()
 

--- a/backend/transcendence/social/friends_views.py
+++ b/backend/transcendence/social/friends_views.py
@@ -106,9 +106,9 @@ class FriendsView(APIView):
 
             #keyword가 비어있는 경우 전체 리스트 반환
             if (keyword == None or keyword == ''):
-                block_list = Friend.objects.filter(user = base_user).order_by('target')
+                friend_list = Friend.objects.filter(user = base_user).order_by('target')
             else:
-                block_list = Friend.objects.filter(user = base_user, target__nickname__icontains = keyword).order_by('target')
+                friend_list = Friend.objects.filter(user = base_user, target__nickname__icontains = keyword).order_by('target')
 
         except:
             return JsonResponse({
@@ -117,7 +117,7 @@ class FriendsView(APIView):
 			}, status = 400)
 
         try :
-            paginator = Paginator(block_list, size)
+            paginator = Paginator(friend_list, size)
             total_page = paginator.num_pages
 
         except:


### PR DESCRIPTION
## ✅ PR 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 수정
- [ ] 기능에 영향을 주지 않는 변경사항
- [ ] 기능 향상
- [ ] 파일 or 폴더명 수정
- [ ] 파일 or 폴더 삭제

## 📰 관련 이슈
<!---- 아래에 주소에 이슈번호를 넣어주세요! ---->
<!---- ex) https://github.com/42EASY/PongPongPingPong/issues/1 ---->
- https://github.com/42EASY/PongPongPingPong/issues/193

## 📝 PR 내용
<!---- 해당 PR에 어떤 작업을 하였는지 설명해주세요. ---->
- 게임 방에서 초대 시에 반환하는 tournament_id 대신 room_id로 변경
- distributed lock에서 redis host를 localhost로 한 부분 변경
- friend_view에서 block_list를 friend_list로 변경
- 토너먼트 게임 시작 시 status 메세지 변경


