### PR TITLE
fix: socket 관련 코드 수정

### DIFF
--- a/frontend/src/components/Chat/ChatRoom/BotContent.js
+++ b/frontend/src/components/Chat/ChatRoom/BotContent.js
@@ -81,15 +81,14 @@ export default function BotContent(data) {
     $botContentBox.appendChild($botContentBtn);
 
     $botContentBtn.onclick = () => {
-      if (
-        !joinInviteTournamentQueue({
-          action: "join_invite_tournament_queue",
-          room_id: data.game_id,
-        })
-      ) {
-        Modal("invalidGame");
-        $botContentBtn.classList.add("invalidBtn");
-      }
+      const res = joinInviteTournamentQueue({
+        action: "join_invite_tournament_queue",
+        room_id: data.game_id,
+      });
+      if (res.message === "인원이 다 찬 게임방입니다")
+        Modal("enterFail_fullRoom");
+      else Modal("invalidGame");
+      $botContentBtn.classList.add("invalidBtn");
     };
   }
   if (data.action === "bot_notify_tournament_game_opponent") {

--- a/frontend/src/components/Friends/Options.js
+++ b/frontend/src/components/Friends/Options.js
@@ -31,7 +31,7 @@ export default function Options(user) {
   $gameOpt.innerHTML = "게임 초대하기";
   $Options.appendChild($gameOpt);
   $gameOpt.addEventListener("click", () => {
-    inviteGame(id, status);
+    inviteGame(user.user_id, user.status);
   });
 
   const $unfriendOpt = document.createElement("li");

--- a/frontend/src/components/GameRoom/PercentBar.js
+++ b/frontend/src/components/GameRoom/PercentBar.js
@@ -8,6 +8,21 @@ export default function PercentBar({ win, lose }) {
   win = Math.round(win);
   lose = 100 - win;
 
+  if (win == 100) {
+    $BarWrapper.className = "percentageBar";
+    $BarWrapper.style.backgroundColor = "#e1effe";
+    $BarWrapper.style.color = "#1c64f2";
+    $BarWrapper.innerHTML = "100%";
+    return $BarWrapper;
+  }
+  if (win == 0) {
+    $BarWrapper.className = "percentageBar";
+    $BarWrapper.style.backgroundColor = "#fde8e8";
+    $BarWrapper.style.color = "#e02424";
+    $BarWrapper.innerHTML = "100%";
+    return $BarWrapper;
+  }
+
   const $winBar = document.createElement("div");
   const $loseBar = document.createElement("div");
   $winBar.className = "percentageBar";

--- a/frontend/src/components/Modal/ModalsInfo.js
+++ b/frontend/src/components/Modal/ModalsInfo.js
@@ -202,7 +202,7 @@ function get_gameStartSoon(argu) {
     title: "게임이 곧 시작됩니다",
     hideCloseButton: true,
     backdropCloseDisabled: true,
-    bodyContent: [TournamentTable(argu.players)],
+    bodyContent: [TournamentTable(argu.player_info)],
     footerContent: [TimerBar()],
   };
 }
@@ -360,7 +360,7 @@ export default function getModalContent(modalName, argu) {
       return get_inviteFail_offline();
     case "inviteFail_inGame":
       return get_inviteFail_inGame();
-    case "enterFaill_fullRoom":
+    case "enterFail_fullRoom":
       return get_enterFail_fullRoom();
     case "chatFail_offline":
       return get_chatFail_offline();

--- a/frontend/src/components/Nav/JoinQueue.js
+++ b/frontend/src/components/Nav/JoinQueue.js
@@ -43,6 +43,7 @@ export function joinInviteTournamentQueue(data) {
       let res = JSON.parse(e.data);
       if (res.status === "success") {
         res["round"] = "SEMI_FINAL";
+        res["room_id"] = data.room_id;
         socket.close();
         changeUrl("/gameroom", res);
       }

--- a/frontend/src/components/Nav/JoinQueue.js
+++ b/frontend/src/components/Nav/JoinQueue.js
@@ -10,6 +10,7 @@ export function joinNormalQueue(data) {
       if (res.status === "game_start_soon") {
         res["mode"] = "NORMAL";
         res["option"] = data.game_mode;
+        socket.close();
         changeUrl("/game", res);
       }
     };
@@ -25,6 +26,7 @@ export function joinInviteNormalQueue(data) {
       if (res.status === "game_start_soon") {
         res["mode"] = "NORMAL";
         res["option"] = data.game_mode;
+        socket.close();
         changeUrl("/game", res);
       }
       if (res.status === "fail") return false;
@@ -41,12 +43,13 @@ export function joinInviteTournamentQueue(data) {
       let res = JSON.parse(e.data);
       if (res.status === "success") {
         res["round"] = "SEMI_FINAL";
+        socket.close();
         changeUrl("/gameroom", res);
       }
-      if (res.status === "fail") return false;
+      if (res.status === "fail") return res;
     };
   }
-  return false;
+  return;
 }
 
 export function cancelNormalQueue(data) {
@@ -62,8 +65,9 @@ export function joinTournamentQueue(data) {
     socket.send(JSON.stringify(data));
     socket.onmessage = (e) => {
       let res = JSON.parse(e.data);
-      if (res.status === "success") {
+      if (res.status === "success" || res.status === "game create success") {
         res["round"] = "SEMI_FINAL";
+        socket.close();
         changeUrl("/gameroom", res);
       }
     };

--- a/frontend/src/pages/Friends.js
+++ b/frontend/src/pages/Friends.js
@@ -6,7 +6,7 @@ import { getFriends, getBlockeds } from "../components/Friends/ListApi.js";
 
 let isFriends = true;
 let curPage = 1;
-let dataSize = 20;
+let dataSize = 30;
 let isFetching = false;
 let hasMore = true;
 

--- a/frontend/src/pages/GameRoom.js
+++ b/frontend/src/pages/GameRoom.js
@@ -45,7 +45,7 @@ export default function GameRoom(data) {
       res["mode"] = "TOURNAMENT";
       res["option"] = "CLASSIC";
       res["round"] = "SEMI_FINAL";
-      Modal("tournamentTable").then(() => {
+      Modal("gameStartSoon", res).then(() => {
         changeUrl("/game", res);
       });
     }
@@ -53,7 +53,7 @@ export default function GameRoom(data) {
       res["mode"] = "TOURNAMENT";
       res["option"] = "CLASSIC";
       res["round"] = "FINAL";
-      Modal("tournamentTable").then(() => {
+      Modal("gameStartSoon", res).then(() => {
         changeUrl("/game", res);
       });
     }

--- a/frontend/src/pages/Nav.js
+++ b/frontend/src/pages/Nav.js
@@ -6,10 +6,13 @@ import { getUserList } from "../components/Nav/NavApi.js";
 import FastGameStart from "../components/Nav/FastGameStart.js";
 import { logout } from "../state/State.js";
 import RoomSocketManager from "../state/RoomSocketManager.js";
+import JoinSocketManager from "../state/JoinSocketManager.js";
 
 export default async function Nav() {
   const $navbar = document.querySelector(".nav");
   $navbar.innerHTML = NavBar().innerHTML;
+
+  JoinSocketManager.getInstance();
 
   //로고 클릭이벤트
   const $navBrand = document.querySelector(".navBrand");

--- a/frontend/src/state/JoinSocketManager.js
+++ b/frontend/src/state/JoinSocketManager.js
@@ -12,6 +12,7 @@ const JoinSocketManager = (() => {
 
     ws.onopen = () => {
       console.log("[joingame - open]");
+      reconnectAttempts = 0; // 연결 성공 시 재연결 시도 횟수 초기화
     };
 
     ws.onclose = (e) => {


### PR DESCRIPTION
## ✅ PR 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 수정
- [ ] 기능에 영향을 주지 않는 변경사항
- [ ] 기능 향상
- [ ] 파일 or 폴더명 수정
- [ ] 파일 or 폴더 삭제

## 📰 관련 이슈
<!---- 아래에 주소에 이슈번호를 넣어주세요! ---->
<!---- ex) https://github.com/42EASY/PongPongPingPong/issues/1 ---->
- https://github.com/42EASY/PongPongPingPong/issues/

## 📝 PR 내용
<!---- 해당 PR에 어떤 작업을 하였는지 설명해주세요. ---->
* 토너먼트 게임 join 시 초대하는 경우 메세지의 status : "game create success" 처리를 추가했습니다

* Friends에서 게임 초대 시 넘기는 인자값이 임시값에서 user의 id와 status를 받을 수 있도록 수정, 
친구 목록 받아올 때 dataSize 크기를 더 많이 받아오도록 수정했습니다
* JoinSocketManager의 재연결 시도 카운트값 초기화, 게임 join이 되면 close()하도록 변경, 
nav에서 다시 connect 시도할 수 있도록 수정했습니다
* 토너먼트 방에 4명 모두 모이게 되면 gameStartSoon 모달 적용했습니다
* 토너먼트 게임 초대 입장 시 이미 게임방에 인원이 4명인 경우 enterFail_fullRoom 모달 적용 적용했습니다
(modalInfo에서 enterFaill_fullRoom으로 오타가 있어서 수정했고 실제로 테스트는 못했습니다)
* 승률이 100%인 경우 0% 글씨가 보이지 않도록 수정했습니다
