### PR TITLE
fix: 토너먼트 전적을 받아올 때 원하는 size 대로 반환하지 않는 현상 수정

### DIFF
--- a/backend/transcendence/members/views.py
+++ b/backend/transcendence/members/views.py
@@ -370,7 +370,7 @@ class MemberGameView(APIView):
 			tournaments = []
 
 			try:
-				for tournament_id in tournament_games:
+				for tournament_id in page_obj:
 					tournament_all_game_list = TournamentGame.objects.filter(tournament_id = tournament_id).order_by('tournament_id')
 					tournaments_game_ids = tournament_all_game_list.values_list('game_id', flat = True)
 		


### PR DESCRIPTION
## ✅ PR 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 수정
- [ ] 기능에 영향을 주지 않는 변경사항
- [ ] 기능 향상
- [ ] 파일 or 폴더명 수정
- [ ] 파일 or 폴더 삭제

## 📰 관련 이슈
<!---- 아래에 주소에 이슈번호를 넣어주세요! ---->
<!---- ex) https://github.com/42EASY/PongPongPingPong/issues/1 ---->


## 📝 PR 내용
<!---- 해당 PR에 어떤 작업을 하였는지 설명해주세요. ---->
- 토너먼트 전적 반환시에 원하는 size대로 반환이 되지 않는 현상 발생하여 이를 수정
