### PR TITLE
fix: 게임의 start, end time이 잘 저장 안되는 현상 수정

### DIFF
--- a/backend/transcendence/games/game_consumer.py
+++ b/backend/transcendence/games/game_consumer.py
@@ -117,7 +117,7 @@ class GameConsumer(AsyncJsonWebsocketConsumer):
         
         self.opponent_channel_name = "-1"
         self.user_participant = await self.get_participant(self.user, self.game)
-        self.opponent_participant =""
+        self.opponent_participant = ""
         await self.accept()
 
 
@@ -201,7 +201,6 @@ class GameConsumer(AsyncJsonWebsocketConsumer):
                         self.opponent = await self.get_members(info["user_id"])
 
                         #user의 participant에 상대 id 값 추가
-                        # self.user_participant = await self.get_participant(self.user, self.game)
                         self.user_participant.opponent_id = self.opponent.id
                         await self.save_participant(self.user_participant)
                         self.user_participant = await self.get_participant(self.user, self.game)

--- a/backend/transcendence/games/game_consumer.py
+++ b/backend/transcendence/games/game_consumer.py
@@ -116,6 +116,8 @@ class GameConsumer(AsyncJsonWebsocketConsumer):
 
         
         self.opponent_channel_name = "-1"
+        self.user_participant = await self.get_participant(self.user, self.game)
+        self.opponent_participant =""
         await self.accept()
 
 
@@ -199,7 +201,7 @@ class GameConsumer(AsyncJsonWebsocketConsumer):
                         self.opponent = await self.get_members(info["user_id"])
 
                         #user의 participant에 상대 id 값 추가
-                        self.user_participant = await self.get_participant(self.user, self.game)
+                        # self.user_participant = await self.get_participant(self.user, self.game)
                         self.user_participant.opponent_id = self.opponent.id
                         await self.save_participant(self.user_participant)
                         self.user_participant = await self.get_participant(self.user, self.game)

--- a/backend/transcendence/games/game_queue_consumer.py
+++ b/backend/transcendence/games/game_queue_consumer.py
@@ -8,6 +8,7 @@ from tournaments.models import Tournament
 from members.models import Members
 from games.distributed_lock import DistributedLock
 from utils import bot_notify_process, get_member_info
+from datetime import datetime, timezone
 
 prefix_normal = "normal_"
 prefix_tournament = "tournament_"
@@ -797,7 +798,9 @@ class GameQueueConsumer(AsyncJsonWebsocketConsumer):
 
         #flag == false면은 새롭게 게임을 만들어서 redis에 저장
         else:
-            new_game = Game.objects.create(game_option=game_mode, game_mode='NORMAL')
+            game_time = datetime.now(timezone.utc)
+
+            new_game = Game.objects.create(game_option=game_mode, game_mode='NORMAL', start_time = game_time, end_time = game_time)
             new_game_value = {
                 "registered_user": [{
                     "user_id" : self.user.id,
@@ -854,7 +857,9 @@ class GameQueueConsumer(AsyncJsonWebsocketConsumer):
             })
             return
 
-        game = Game.objects.create(game_option=game_mode, game_mode='NORMAL')
+        game_time = datetime.now(timezone.utc)
+
+        game = Game.objects.create(game_option=game_mode, game_mode='NORMAL', start_time = game_time, end_time = game_time)
 
         value = {
             "registered_user": [{

--- a/backend/transcendence/games/game_room_consumer.py
+++ b/backend/transcendence/games/game_room_consumer.py
@@ -98,6 +98,8 @@ class GameRoomConsumer(AsyncJsonWebsocketConsumer):
                     Participant.objects.create(user_id = self.user.id, game_id = game, score = 0, opponent_id = opponent.id, result = Participant.Result.LOSE)
                     Participant.objects.create(user_id = opponent.id, game_id = game, score = 0, opponent_id = self.user.id, result = Participant.Result.WIN)
 
+
+                    #게임의 start_time, end_time 갱신
                     game_time = datetime.now(timezone.utc)
                     
                     game.start_time = game_time
@@ -122,6 +124,7 @@ class GameRoomConsumer(AsyncJsonWebsocketConsumer):
                     opponent_participants.save()
 
 
+                    #게임의 start_time, end_time 갱신
                     game = Game.objects.get(id = user_participants.game_id)
                     
                     game_time = datetime.now(timezone.utc)
@@ -132,7 +135,6 @@ class GameRoomConsumer(AsyncJsonWebsocketConsumer):
                     game.save()
 
 
-                    #TODO: 게임 start_time, end_time 업데이트
                     
             except:
                 await self.send_json({

--- a/backend/transcendence/games/game_room_consumer.py
+++ b/backend/transcendence/games/game_room_consumer.py
@@ -91,7 +91,9 @@ class GameRoomConsumer(AsyncJsonWebsocketConsumer):
                 
                 #결승에 대한 게임 db가 만들어져있지 않다면 새롭게 만들어서 승패 처리
                 if (len(TournamentGame.objects.filter(tournament_id = self.tournament)) < 3):
-                    game = Game.objects.create(game_mode = Game.GameMode.TOURNAMENT)
+                    game_time = datetime.now(timezone.utc)
+
+                    game = Game.objects.create(game_mode = Game.GameMode.TOURNAMENT, start_time = game_time, end_time = game_time)
             
                     TournamentGame.objects.create(game_id = game, tournament_id = self.tournament, round = TournamentGame.Round.FINAL)
 
@@ -542,7 +544,8 @@ class GameRoomConsumer(AsyncJsonWebsocketConsumer):
             #game과 participant, tournamentgame 생성
             try:
                 #승률을 기준으로 정렬한 sorted_matching_value[0]과 sorted_matching_value[1]이 서로 한 게임을 하도록 game, participant, tournament 테이블 생성
-                game1 = Game.objects.create(game_mode = Game.GameMode.TOURNAMENT)
+                game_time = datetime.now(timezone.utc)
+                game1 = Game.objects.create(game_mode = Game.GameMode.TOURNAMENT, start_time = game_time, end_time = game_time)
 
                 Participant.objects.create(user_id = Members.objects.get(id=sorted_matching_value[0]["user_id"]), game_id = game1, score = 0, opponent_id = sorted_matching_value[1]["user_id"])
                 Participant.objects.create(user_id = Members.objects.get(id=sorted_matching_value[1]["user_id"]), game_id = game1, score = 0, opponent_id = sorted_matching_value[0]["user_id"])
@@ -550,7 +553,7 @@ class GameRoomConsumer(AsyncJsonWebsocketConsumer):
                 TournamentGame.objects.create(game_id = game1, tournament_id = self.tournament, round = TournamentGame.Round.SEMI_FINAL)
 
                 #승률을 기준으로 정렬한 sorted_matching_value[2]과 sorted_matching_value[3]이 서로 한 게임을 하도록 game, participant, tournament 테이블 생성
-                game2 = Game.objects.create(game_mode = Game.GameMode.TOURNAMENT)
+                game2 = Game.objects.create(game_mode = Game.GameMode.TOURNAMENT, start_time = game_time, end_time = game_time)
 
                 Participant.objects.create(user_id = Members.objects.get(id=sorted_matching_value[2]["user_id"]), game_id = game2, score = 0, opponent_id = sorted_matching_value[3]["user_id"])
                 Participant.objects.create(user_id = Members.objects.get(id=sorted_matching_value[3]["user_id"]), game_id = game2, score = 0, opponent_id = sorted_matching_value[2]["user_id"])
@@ -776,7 +779,8 @@ class GameRoomConsumer(AsyncJsonWebsocketConsumer):
 
 
             try:
-                game = Game.objects.create(game_mode = Game.GameMode.TOURNAMENT)
+                game_time = datetime.now(timezone.utc)
+                game = Game.objects.create(game_mode = Game.GameMode.TOURNAMENT, start_time = game_time, end_time = game_time)
             
                 TournamentGame.objects.create(game_id = game, tournament_id = self.tournament, round = TournamentGame.Round.FINAL)
 


### PR DESCRIPTION
## ✅ PR 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 수정
- [ ] 기능에 영향을 주지 않는 변경사항
- [ ] 기능 향상
- [ ] 파일 or 폴더명 수정
- [ ] 파일 or 폴더 삭제

## 📰 관련 이슈
<!---- 아래에 주소에 이슈번호를 넣어주세요! ---->
<!---- ex) https://github.com/42EASY/PongPongPingPong/issues/1 ---->
- https://github.com/42EASY/PongPongPingPong/issues/229

## 📝 PR 내용
<!---- 해당 PR에 어떤 작업을 하였는지 설명해주세요. ---->
- 전적 검색시 게임의 start_time, end_time이 제대로 저장되지 않아서 400에러 발생하였고, 이를 수정 
