### PR TITLE
fix: scroll , joingame과 gameroom 소켓 수정

### DIFF
--- a/frontend/src/components/Chat/ChatRoom/BotContent.js
+++ b/frontend/src/components/Chat/ChatRoom/BotContent.js
@@ -63,14 +63,15 @@ export default function BotContent(data) {
     $botContentBox.appendChild($botContentBtn);
 
     $botContentBtn.onclick = () => {
-      const res = joinInviteTournamentQueue({
-        action: "join_invite_tournament_queue",
-        room_id: data.game_id,
-      });
-      if (res.message === "인원이 다 찬 게임방입니다")
-        Modal("enterFail_fullRoom");
-      else Modal("invalidGame");
-      $botContentBtn.classList.add("invalidBtn");
+      if (
+        !joinInviteNormalQueue({
+          action: "join_invite_normal_queue",
+          game_id: data.game_id,
+        })
+      ) {
+        Modal("invalidGame");
+        $botContentBtn.classList.add("invalidBtn");
+      }
     };
   }
   if (data.action === "bot_notify_invited_tournament_game") {
@@ -80,15 +81,14 @@ export default function BotContent(data) {
     $botContentBox.appendChild($botContentBtn);
 
     $botContentBtn.onclick = () => {
-      if (
-        !joinInviteTournamentQueue({
-          action: "join_invite_tournament_queue",
-          room_id: data.room_id,
-        })
-      ) {
-        Modal("invalidGame");
-        $botContentBtn.classList.add("invalidBtn");
-      }
+      const res = joinInviteTournamentQueue({
+        action: "join_invite_tournament_queue",
+        room_id: data.game_id,
+      });
+      if (res.message === "인원이 다 찬 게임방입니다")
+        Modal("enterFail_fullRoom");
+      else Modal("invalidGame");
+      $botContentBtn.classList.add("invalidBtn");
     };
   }
   if (data.action === "bot_notify_tournament_game_opponent") {

--- a/frontend/src/components/Modal/Modal.js
+++ b/frontend/src/components/Modal/Modal.js
@@ -16,6 +16,9 @@ export default function Modal(modalName, argu) {
       .addEventListener("click", (event) => {
         event.stopPropagation();
       });
+    $modalWrapper.addEventListener("mouseover", () => {
+      document.body.style.overflow = "hidden";
+    });
 
     // [모달 창 닫는 부분]
     const $closeButtons = document.getElementsByClassName("close");
@@ -26,6 +29,7 @@ export default function Modal(modalName, argu) {
         const input = getInputValue(modalName);
         if (inputTag && isPositive && !input) return;
 
+        document.body.style.overflow = "auto";
         $app.removeChild($modalWrapper);
         return inputTag
           ? resolve({ isPositive, input })

--- a/frontend/src/components/Modal/ModalsInfo.js
+++ b/frontend/src/components/Modal/ModalsInfo.js
@@ -362,7 +362,7 @@ export default function getModalContent(modalName, argu) {
       return get_inviteFail_inGame();
     case "enterFail_fullRoom":
       return get_enterFail_fullRoom();
-    case "chatFail_offline":
+    case "chatFail_offlineUser":
       return get_chatFail_offline();
     case "chatFail_blockedUser":
       return get_chatFail_blockedUser();

--- a/frontend/src/pages/ChatRoom.js
+++ b/frontend/src/pages/ChatRoom.js
@@ -26,14 +26,16 @@ async function sendMessage(user, me, roomName) {
   // 사용자 상태 확인
   const userStatus = chatUserState.getUserState()[user.user_id];
   if (userStatus) {
-      // isBlocked가 true이거나 isOnline이 false일 경우 메시지 전송 방지
-      if (!userStatus.isOnline) {
-        Modal("chatFail_offlineUser");
-        return ;
-      } else if (userStatus.isBlocked) {
-        Modal("chatFail_blockedUser");
-        return ;
-      }
+    // isBlocked가 true이거나 isOnline이 false일 경우 메시지 전송 방지
+    if (!userStatus.isOnline) {
+      Modal("chatFail_offlineUser");
+      $chatInput.blur();
+      return;
+    } else if (userStatus.isBlocked) {
+      Modal("chatFail_blockedUser");
+      $chatInput.blur();
+      return;
+    }
   }
 
   const data = {
@@ -62,8 +64,7 @@ async function sendMessage(user, me, roomName) {
 }
 
 async function receiveMessage(user, data, roomName) {
-  if (data.sender.user_id !== user.user_id)
-    return ;
+  if (data.sender.user_id !== user.user_id) return;
   const $chatContents = document.querySelector("#chatContents");
 
   $chatContents.appendChild(ChatContent(user, data));
@@ -117,7 +118,7 @@ export default function ChatRoom(user) {
   socket.onmessage = function (event) {
     const data = JSON.parse(event.data);
     console.log(data);
-    
+
     if (data.action === "fetch_messages") {
       const messages = data.messages;
       fetchMessages(messages);
@@ -133,17 +134,16 @@ export default function ChatRoom(user) {
     } else if (data.action === "update_user_status") {
       const userId = data.user_id;
       const isOnline = data.status === "ONLINE";
-      chatUserState.setUserState(userId, {isOnline : isOnline});
+      chatUserState.setUserState(userId, { isOnline: isOnline });
     }
 
     if (data.status === "fail") {
       if (data.type === "blocked_chat_user") {
         Modal("chatFail_blockedUser");
-        chatUserState.setUserState(user.user_id, {isBlocked : true});
-      }
-      else if (data.type === "offline_chat_user")
+        chatUserState.setUserState(user.user_id, { isBlocked: true });
+      } else if (data.type === "offline_chat_user")
         Modal("chatFail_offlineUser");
-        chatUserState.setUserState(user.user_id, {isOnline : false});
+      chatUserState.setUserState(user.user_id, { isOnline: false });
     }
   };
 

--- a/frontend/src/pages/GameRoom.js
+++ b/frontend/src/pages/GameRoom.js
@@ -57,7 +57,6 @@ export default function GameRoom(data) {
         changeUrl("/game", res);
       });
     }
-
     if (res.status === "player_entrance") {
       let i;
       for (i = 0; i < res.player_info.length; i++) {
@@ -68,6 +67,14 @@ export default function GameRoom(data) {
         waitingPlayersArr[j].innerHTML = "";
         waitingPlayersArr[j].appendChild(WaitingPlayer());
       }
+    }
+    if (res.status === "game_over") {
+      Modal("invalidGame");
+      const modalTitle = document.querySelector(".modalTitle");
+      modalTitle.innerHTML = "게임이 종료되었습니다";
+      const modalText = document.querySelector(".modalText");
+      modalText.innerHTML = "게임 상대의 연결이 끊어졌습니다";
+      changeUrl("/main");
     }
   };
 }

--- a/frontend/src/pages/Nav.js
+++ b/frontend/src/pages/Nav.js
@@ -17,10 +17,7 @@ export default async function Nav() {
   //로고 클릭이벤트
   const $navBrand = document.querySelector(".navBrand");
   $navBrand.addEventListener("click", () => {
-    if (window.location.pathname === "/gameroom") {
-      const socket = RoomSocketManager.getInstance();
-      if (socket) socket.close();
-    }
+    if (window.location.pathname === "/gameroom") RoomSocketManager.close();
     changeUrl("/main");
   });
 
@@ -69,10 +66,7 @@ export default async function Nav() {
       $item = document.getElementById("navSearchItem" + idx);
       $item.classList.add("navSearchItemSelected");
     } else if (e.key === "Enter") {
-      if (window.location.pathname === "/gameroom") {
-        const socket = RoomSocketManager.getInstance();
-        if (socket) socket.close();
-      }
+      if (window.location.pathname === "/gameroom") RoomSocketManager.close();
       if (idx !== -1)
         changeUrl(
           `/main=${arr.get(
@@ -94,10 +88,8 @@ export default async function Nav() {
             $searchList.appendChild($searchItem);
             arr.set($searchItem.innerHTML, list.result.data[i].user_id);
             $searchItem.onclick = (e) => {
-              if (window.location.pathname === "/gameroom") {
-                const socket = RoomSocketManager.getInstance();
-                if (socket) socket.close();
-              }
+              if (window.location.pathname === "/gameroom")
+                RoomSocketManager.close();
               changeUrl(`/main=${arr.get(e.target.innerHTML)}`);
             };
           }

--- a/frontend/src/state/JoinSocketManager.js
+++ b/frontend/src/state/JoinSocketManager.js
@@ -33,8 +33,8 @@ const JoinSocketManager = (() => {
     };
 
     ws.onerror = (e) => {
-      console.log("[joingame - error]");
-      console.log(e);
+      console.log("[joingame - error]: ", e);
+      ws.close();
     };
 
     return ws;

--- a/frontend/src/state/RoomSocketManager.js
+++ b/frontend/src/state/RoomSocketManager.js
@@ -15,8 +15,8 @@ const RoomSocketManager = (() => {
     };
 
     ws.onerror = (e) => {
-      console.log("[gameroom - error]");
-      console.log(e);
+      console.log("[gameroom - error]: ", e);
+      ws.close();
     };
 
     return ws;
@@ -32,6 +32,9 @@ const RoomSocketManager = (() => {
         instance = init(room_id);
       }
       return instance;
+    },
+    close: function () {
+      if (instance) instance.close();
     },
   };
 })();


### PR DESCRIPTION
## ✅ PR 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 수정
- [ ] 기능에 영향을 주지 않는 변경사항
- [ ] 기능 향상
- [ ] 파일 or 폴더명 수정
- [ ] 파일 or 폴더 삭제

## 📰 관련 이슈
<!---- 아래에 주소에 이슈번호를 넣어주세요! ---->
<!---- ex) https://github.com/42EASY/PongPongPingPong/issues/1 ---->
- https://github.com/42EASY/PongPongPingPong/issues/

## 📝 PR 내용
<!---- 해당 PR에 어떤 작업을 하였는지 설명해주세요. ---->
Modal
* 모달 뒤 화면 스크롤 되지 않도록 했습니다
* chatFail_offline -> chatFail_offlineUser 로 모달명 수정했습니다
* chatFail_offlineUser 호출 시 계속해서 input에 메세지 입력이 가능하던 부분 수정했습니다

Sidebar
* Chat, Friends의 목록에 스크롤이 없는 경우 사이드바 외부의 화면이 스크롤 되던 부분 수정했습니다
* 수정하면서 chat.js에 프리티어가 적용되어 포맷이 일부 변경되었습니다
* 게임초대 메세지 노말과 토너먼트 부분이 잘못 연결되어 있어서 수정했습니다

GameRoom
* 토너먼트 게임 대기 방에서 결승 대기 중인 상황에 상대방의 연결이 끊기게 되면 메인 페이지로 이동하도록 했습니다
* 소켓에 close 함수를 추가하고 게임방에서 페이지 이동이 발생할 때 추가한 함수를 사용하도록 수정했습니다
* joinsocketmanager와 roomsocketmanager에 에러 발생 시 명시적으로 소켓을 close 하도록 수정했습니다

