### PR TITLE
fix: 빠른 게임 후 스크롤 동작하도록 수정

### DIFF
--- a/frontend/src/components/Modal/Modal.js
+++ b/frontend/src/components/Modal/Modal.js
@@ -16,9 +16,8 @@ export default function Modal(modalName, argu) {
       .addEventListener("click", (event) => {
         event.stopPropagation();
       });
-    $modalWrapper.addEventListener("mouseover", () => {
-      document.body.style.overflow = "hidden";
-    });
+
+    document.body.style.overflow = "hidden";
 
     // [모달 창 닫는 부분]
     const $closeButtons = document.getElementsByClassName("close");

--- a/frontend/src/pages/Main.js
+++ b/frontend/src/pages/Main.js
@@ -8,6 +8,7 @@ import { getUserInfo } from "../components/Main/UserApi.js";
 export default async function Main() {
   Nav();
 
+  document.body.style.overflow = "auto";
   const $app = document.querySelector(".App");
   $app.innerHTML = "";
   const $page = document.createElement("div");


### PR DESCRIPTION
## ✅ PR 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 수정
- [ ] 기능에 영향을 주지 않는 변경사항
- [ ] 기능 향상
- [ ] 파일 or 폴더명 수정
- [ ] 파일 or 폴더 삭제

## 📰 관련 이슈
<!---- 아래에 주소에 이슈번호를 넣어주세요! ---->
<!---- ex) https://github.com/42EASY/PongPongPingPong/issues/1 ---->
- https://github.com/42EASY/PongPongPingPong/issues/

## 📝 PR 내용
<!---- 해당 PR에 어떤 작업을 하였는지 설명해주세요. ---->
* 빠른 게임시작 같은 모달창을 닫는 이벤트없이 페이지 이동하게 되면 스크롤이 없어지는 문제 해결했습니다
