### PR TITLE
fix: 매칭 진행 중 의도치 않은 매칭 종료 후 게임 전적 페이지 400 뜨는 현상 수정

### DIFF
--- a/backend/transcendence/games/game_queue_consumer.py
+++ b/backend/transcendence/games/game_queue_consumer.py
@@ -839,15 +839,6 @@ class GameQueueConsumer(AsyncJsonWebsocketConsumer):
            
             self.key = prefix_normal + str(new_game.id)
 
-            # try:
-            #     Participant.objects.create(user_id = Members.objects.get(id = self.user.id), game_id = new_game, score = 0)
-            # except:
-            #     await self.send_json({
-            #         "status": "fail",
-            #         "message": "db에서 오류가 발생했습니다"
-            #     })
-            #     return
-
 
 
     #normal 모드에서 초대를 한 경우
@@ -898,14 +889,6 @@ class GameQueueConsumer(AsyncJsonWebsocketConsumer):
             })
             return
         
-        # try:
-        #     Participant.objects.create(user_id = Members.objects.get(id = self.user.id), game_id = game, score = 0)
-        # except:
-        #     await self.send_json({
-        #         "status": "fail",
-        #         "message": "db에서 오류가 발생했습니다"
-        #     })
-        #     return
         
         self.key = prefix_normal + str(game.id)
 

--- a/backend/transcendence/games/game_queue_consumer.py
+++ b/backend/transcendence/games/game_queue_consumer.py
@@ -722,7 +722,12 @@ class GameQueueConsumer(AsyncJsonWebsocketConsumer):
             join_game_key = key
 
             try:
-                Participant.objects.create(user_id = Members.objects.get(id = self.user.id), game_id = game, score = 0)
+                user1 = Members.objects.get(id = new_parsed_value['registered_user'][0]['user_id'])
+                user2 = Members.objects.get(id = new_parsed_value['registered_user'][1]['user_id'])
+
+                Participant.objects.create(user_id = user1, opponent_id = user2.id, game_id = game, score = 0)
+                Participant.objects.create(user_id = user2, opponent_id = user1.id, game_id = game, score = 0)
+
             except:
                 await self.send_json({
                     "status": "fail",
@@ -834,14 +839,14 @@ class GameQueueConsumer(AsyncJsonWebsocketConsumer):
            
             self.key = prefix_normal + str(new_game.id)
 
-            try:
-                Participant.objects.create(user_id = Members.objects.get(id = self.user.id), game_id = new_game, score = 0)
-            except:
-                await self.send_json({
-                    "status": "fail",
-                    "message": "db에서 오류가 발생했습니다"
-                })
-                return
+            # try:
+            #     Participant.objects.create(user_id = Members.objects.get(id = self.user.id), game_id = new_game, score = 0)
+            # except:
+            #     await self.send_json({
+            #         "status": "fail",
+            #         "message": "db에서 오류가 발생했습니다"
+            #     })
+            #     return
 
 
 
@@ -893,14 +898,14 @@ class GameQueueConsumer(AsyncJsonWebsocketConsumer):
             })
             return
         
-        try:
-            Participant.objects.create(user_id = Members.objects.get(id = self.user.id), game_id = game, score = 0)
-        except:
-            await self.send_json({
-                "status": "fail",
-                "message": "db에서 오류가 발생했습니다"
-            })
-            return
+        # try:
+        #     Participant.objects.create(user_id = Members.objects.get(id = self.user.id), game_id = game, score = 0)
+        # except:
+        #     await self.send_json({
+        #         "status": "fail",
+        #         "message": "db에서 오류가 발생했습니다"
+        #     })
+        #     return
         
         self.key = prefix_normal + str(game.id)
 
@@ -1082,7 +1087,10 @@ class GameQueueConsumer(AsyncJsonWebsocketConsumer):
             return
 
         try:
-            Participant.objects.create(user_id = Members.objects.get(id = self.user.id), game_id = Game.objects.get(id = game_id), score = 0)
+            opponent_user = Members.objects.get(id = int(new_parsed_value['registered_user'][0]["user_id"]))
+            game = Game.objects.get(id = game_id)
+            Participant.objects.create(user_id = opponent_user, opponent_id = self.user.id, game_id = game, score = 0)
+            Participant.objects.create(user_id = self.user, opponent_id = opponent_user.id, game_id = game, score = 0)
         except:
             await self.send_json({
                 "status": "fail",


### PR DESCRIPTION
## ✅ PR 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 수정
- [ ] 기능에 영향을 주지 않는 변경사항
- [ ] 기능 향상
- [ ] 파일 or 폴더명 수정
- [ ] 파일 or 폴더 삭제

## 📰 관련 이슈
<!---- 아래에 주소에 이슈번호를 넣어주세요! ---->
<!---- ex) https://github.com/42EASY/PongPongPingPong/issues/1 ---->
- https://github.com/42EASY/PongPongPingPong/issues/247

## 📝 PR 내용
<!---- 해당 PR에 어떤 작업을 하였는지 설명해주세요. ---->

- 매칭 진행 중 의도치 않은 매칭 종료 후 게임 전적 페이지 400 뜨는 현상 발생
- participant 테이블에 opponent_id가 null 값이 들어가 있어 해당 현상이 발생한 것이라고 판단

- 기존 participant는 game이 만들어질 때 opponent_id 값을 비워둔 채로 생성 후, 게임 상대가 정해지면 그때 update 하도록 처리해놓았는데, 이를 게임 상대가 정해질 때 participant가 한번에 만들어질 수 있도록 수정