### PR TITLE
fix: game over시에 result도 전송하도록 추가

### DIFF
--- a/backend/transcendence/games/game_board_consumer.py
+++ b/backend/transcendence/games/game_board_consumer.py
@@ -188,8 +188,8 @@ class GameBoardConsumer(AsyncWebsocketConsumer):
                             'type': 'broadcast_game_status',
                             'message': 'game_over',
                             'game_status': [
-                                {"user_id": loser, "score": self.game_board.scores['player1']},
-                                {"user_id": winner, "score": self.game_board.scores['player2']}
+                                {"user_id": loser, "score": self.game_board.scores['player1'], "result": Participant.Result.LOSE},
+                                {"user_id": winner, "score": self.game_board.scores['player2'], "result": Participant.Result.WIN}
                             ]
                         }
                     )
@@ -261,8 +261,8 @@ class GameBoardConsumer(AsyncWebsocketConsumer):
         game_over_message = {
         'action': 'game_over',
         'game_status': [
-            {"user_id": self.player1_id, "score": self.game_board.scores['player1']},
-            {"user_id": self.player2_id, "score": self.game_board.scores['player2']}
+            {"user_id": self.player1_id, "score": self.game_board.scores['player1'], "result": player1_result},
+            {"user_id": self.player2_id, "score": self.game_board.scores['player2'], "result": player2_result}
             ]
         }
 


### PR DESCRIPTION
## ✅ PR 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 수정
- [ ] 기능에 영향을 주지 않는 변경사항
- [ ] 기능 향상
- [ ] 파일 or 폴더명 수정
- [ ] 파일 or 폴더 삭제

## 📰 관련 이슈
<!---- 아래에 주소에 이슈번호를 넣어주세요! ---->
<!---- ex) https://github.com/42EASY/PongPongPingPong/issues/1 ---->
- https://github.com/42EASY/PongPongPingPong/issues/250

## 📝 PR 내용
<!---- 해당 PR에 어떤 작업을 하였는지 설명해주세요. ---->
- 게임 game_over 시에 현재 user_id, score만 반환하도록 되어있는데, result도 추가로 반환하도록 수정
