### PR TITLE
fix: 게임 전적을 start time 기준으로 내림차순 정렬

### DIFF
--- a/backend/transcendence/members/views.py
+++ b/backend/transcendence/members/views.py
@@ -243,8 +243,7 @@ class MemberGameView(APIView):
 		if (mode == Game.GameMode.NORMAL):
 
 			try:
-				game_list = Participant.objects.filter(user_id = user_id, game_id__game_mode=Game.GameMode.NORMAL).order_by('user_id')
-
+				game_list = Participant.objects.filter(user_id = user_id, game_id__game_mode = Game.GameMode.NORMAL).order_by('-game_id__start_time')
 			except:
 				return JsonResponse({
 					'code': 400,
@@ -283,10 +282,10 @@ class MemberGameView(APIView):
 			try: 
 				for participant in page_obj:
 					game = participant.game_id
-	
+
 					participants_in_game = Participant.objects.filter(game_id = game) 
 					user_ids_in_game = participants_in_game.values_list('user_id', flat = True)
-				
+			
 					opponent_player = Members.objects.exclude(id=user_id).get(id__in=user_ids_in_game)
 
 					participant_opponent_player = Participant.objects.get(game_id = game, user_id = opponent_player)
@@ -332,7 +331,7 @@ class MemberGameView(APIView):
 			try:
 				game_list = Participant.objects.filter(user_id = user, game_id__game_mode=Game.GameMode.TOURNAMENT).order_by('user_id')
 				game_ids = game_list.values_list('game_id', flat = True)
-				tournament_games_list= TournamentGame.objects.filter(game_id__in = game_ids).order_by('tournament_id')
+				tournament_games_list= TournamentGame.objects.filter(game_id__in = game_ids).order_by('-game_id__start_time')
 				tournament_games = tournament_games_list.values_list('tournament_id', flat = True).distinct()
 	
 			except:


### PR DESCRIPTION
## ✅ PR 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 수정
- [ ] 기능에 영향을 주지 않는 변경사항
- [ ] 기능 향상
- [ ] 파일 or 폴더명 수정
- [ ] 파일 or 폴더 삭제

## 📰 관련 이슈
<!---- 아래에 주소에 이슈번호를 넣어주세요! ---->
<!---- ex) https://github.com/42EASY/PongPongPingPong/issues/1 ---->
- https://github.com/42EASY/PongPongPingPong/issues/252

## 📝 PR 내용
<!---- 해당 PR에 어떤 작업을 하였는지 설명해주세요. ---->
- 게임 전적을 start_time을 기준으로 내림차순으로 정렬하도록 수정
