### PR TITLE
fix: tournament, noraml로 나누어 player_info 처리

### DIFF
--- a/frontend/src/components/Game/RemoteBoard.js
+++ b/frontend/src/components/Game/RemoteBoard.js
@@ -157,10 +157,15 @@ function changeUrl(info, result, requestedUrl) {
   EndGame({ info: info, result: result });
 }
 
-export default function RemoteBoard(info) {
+export default function RemoteBoard(info, rightUser_id) {
   console.log("REMOTE BOARD: ", info);
   const socket = GameBoardSocketManager.getInstance(info.game_id);
-  const opponentInfo = info.player_info;
+  let opponentInfo;
+  if (rightUser_id)
+    opponentInfo = info.player_info.find(
+      (player) => player.user_id !== rightUser_id
+    );
+  else opponentInfo = info.player_info;
 
   canvas.height = 550;
   canvas.width = canvas.height * 1.45;

--- a/frontend/src/pages/Game.js
+++ b/frontend/src/pages/Game.js
@@ -1,4 +1,5 @@
-import { getMyInfo } from "../state/State.js";
+import { getMyInfo, getNumberUserId } from "../state/State.js";
+import { getUserInfo } from "../components/Main/UserApi.js";
 import Info from "../components/Game/Info.js";
 import Board from "../components/Game/Board.js";
 import RemoteBoard from "../components/Game/RemoteBoard.js";
@@ -18,10 +19,18 @@ export default async function Game(data) {
   if (data.mode === "2P") {
     $info = Info(rightInfo, rightInfo);
     $board = Board(data, rightInfo.user_id);
-  } else {
+  } else if (data.mode === "TOURNAMENT") {
     const leftInfo = data.player_info;
     $info = Info(leftInfo, rightInfo);
     $board = RemoteBoard(data);
+  } else if (data.mode === "NORMAL") {
+    const leftUserId =
+      data.player_info[0].user_id === getNumberUserId()
+        ? data.player_info[1].user_id
+        : data.player_info[0].user_id;
+    const leftInfo = await getUserInfo(leftUserId);
+    $info = Info(leftInfo.result, rightInfo);
+    $board = RemoteBoard(data, rightInfo.user_id);
   }
 
   $page.appendChild($info);


### PR DESCRIPTION
## ✅ PR 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 수정
- [ ] 기능에 영향을 주지 않는 변경사항
- [ ] 기능 향상
- [ ] 파일 or 폴더명 수정
- [ ] 파일 or 폴더 삭제

## 📰 관련 이슈
<!---- 아래에 주소에 이슈번호를 넣어주세요! ---->
<!---- ex) https://github.com/42EASY/PongPongPingPong/issues/1 ---->
- https://github.com/42EASY/PongPongPingPong/issues/

## 📝 PR 내용
<!---- 해당 PR에 어떤 작업을 하였는지 설명해주세요. ---->

* game에서 받는 data 값이 NORMAL 모드인 경우와 TOURNAMENT 모드인 경우 값이 달라서
게임 상단에 표시되는 유저 정보 값이 제대로 표시되지 않는 부분 수정했습니다.

