### PR TITLE
fix: 서버와 nginx 인증서 분리

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -42,8 +42,25 @@ ENV DOCKERIZE_VERSION v0.2.0
 RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
-RUN mkdir -p /app/keys/certs && \
-    mkdir -p /app/keys/private
+# 인증서
+RUN apt-get install --reinstall ca-certificates
+
+# 필요한 패키지 설치
+RUN apt-get install -y wget
+
+# mkcert 설치
+RUN wget https://github.com/FiloSottile/mkcert/releases/download/v1.4.3/mkcert-v1.4.3-linux-amd64 -O mkcert && \
+    chmod +x mkcert && \
+    mv mkcert /usr/local/bin/
+
+# mkcert 실행 및 인증서 생성
+RUN mkcert -install && mkcert localhost
+
+RUN mkcert localhost 127.0.0.1 ::1
+
+RUN \
+    mv localhost.pem /etc/ssl/certs/localhost.pem && \
+    mv localhost-key.pem /etc/ssl/private/localhost.key
 
 #RUN django-admin startproject transcendence
 

--- a/backend/docker_entrypoint.sh
+++ b/backend/docker_entrypoint.sh
@@ -16,4 +16,4 @@ cd /app/transcendence
 # TODO: 개발용 추후 삭제
 python /app/transcendence/run_daphne.py
 
-# daphne -e ssl:8443:privateKey=/app/keys/private/localhost-key.pem:certKey=/app/keys/certs/localhost.pem transcendence.asgi:application
+# daphne -e ssl:8443:privateKey=/etc/ssl/private/localhost.key:certKey=/etc/ssl/certs/localhost.pem transcendence.asgi:application

--- a/backend/transcendence/run_daphne.py
+++ b/backend/transcendence/run_daphne.py
@@ -4,7 +4,7 @@ from subprocess import Popen
 import os
 
 def runserver():
-    cmd = ['daphne', '-e', 'ssl:8443:privateKey=/app/keys/private/localhost-key.pem:certKey=/app/keys/certs/localhost.pem', 'transcendence.asgi:application']
+    cmd = ['daphne', '-e', 'ssl:8443:privateKey=/etc/ssl/private/localhost.key:certKey=/etc/ssl/certs/localhost.pem', 'transcendence.asgi:application']
     process = Popen(cmd)
     try:
         for changes in watch('/app/transcendence'):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,8 +33,6 @@ services:
       - transcendence
     volumes:
       - ./backend/transcendence:/app/transcendence
-      - ./ssl/certs/localhost.pem:/app/keys/certs/localhost.pem
-      - ./ssl/private/localhost-key.pem:/app/keys/private/localhost-key.pem
     depends_on:
       - db
       - redis
@@ -57,8 +55,6 @@ services:
     volumes:
       - ./frontend:/app/frontend
       - ./backend/transcendence/media:/app/backend/transcendence/media
-      - ./ssl/certs/localhost.pem:/etc/ssl/certs/localhost.pem
-      - ./ssl/private/localhost-key.pem:/etc/ssl/private/localhost-key.pem
     
   redis:
     image: redis:7.2-bookworm

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -3,7 +3,26 @@ FROM nginx:latest
 RUN \
     apt-get -y update && \
     apt-get -y upgrade && \
-    apt-get install -y openssl
+    apt-get install -y openssl && \
+
+    apt-get install --reinstall ca-certificates
+
+# 필요한 패키지 설치
+RUN apt-get install -y wget
+
+# mkcert 설치
+RUN wget https://github.com/FiloSottile/mkcert/releases/download/v1.4.3/mkcert-v1.4.3-linux-amd64 -O mkcert && \
+    chmod +x mkcert && \
+    mv mkcert /usr/local/bin/
+
+# mkcert 실행 및 인증서 생성
+RUN mkcert -install && mkcert localhost
+
+RUN mkcert localhost 127.0.0.1 ::1
+
+RUN \
+    mv localhost.pem /etc/ssl/certs/localhost.pem && \
+    mv localhost-key.pem /etc/ssl/private/localhost.key
 
 COPY ./default /etc/nginx/conf.d/default.conf
  

--- a/nginx/default
+++ b/nginx/default
@@ -35,7 +35,7 @@ server {
 
 	ssl_protocols TLSv1.2 TLSv1.3;
 	ssl_certificate /etc/ssl/certs/localhost.pem;
- 	ssl_certificate_key /etc/ssl/private/localhost-key.pem;# 	ssl_protocols TLSv1.2 TLSv1.3;
+ 	ssl_certificate_key /etc/ssl/private/localhost.key;# 	ssl_protocols TLSv1.2 TLSv1.3;
 
 # # 	
 # 	# Note: You should disable gzip for SSL traffic.


### PR DESCRIPTION
## ✅ PR 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드 수정
- [ ] 기능에 영향을 주지 않는 변경사항
- [ ] 기능 향상
- [ ] 파일 or 폴더명 수정
- [ ] 파일 or 폴더 삭제

## 📰 관련 이슈
<!---- 아래에 주소에 이슈번호를 넣어주세요! ---->
<!---- ex) https://github.com/42EASY/PongPongPingPong/issues/1 ---->
- https://github.com/42EASY/PongPongPingPong/issues/262

## 📝 PR 내용
<!---- 해당 PR에 어떤 작업을 하였는지 설명해주세요. ---->
- 개발 및 평가 시 편의를 위해 각각의 인증서를 발급받아 ssl 통신이 가능하도록 변경
- 배포 시에는 다른 방식으로 인증서를 받도록 수정
