### PR TITLE
fix: register 페이지 버그 수정 및 로그인 없이 url로 페이지 이동 제한 적용

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,3 @@
 import changeUrl from "./Router.js";
-import { setNewAccessToken } from "./state/State.js";
 
-//todo: url 입력으로 넘어가지 않아야 하는 페이지 예외처리 필요
 changeUrl(window.location.pathname);

--- a/frontend/src/Router.js
+++ b/frontend/src/Router.js
@@ -37,6 +37,7 @@ function checkUrl(requestedUrl) {
 
 export default function changeUrl(requestedUrl, element) {
   //화면 초기화
+  document.body.style.display = "none";
   const $app = document.querySelector(".App");
   $app.innerHTML = "";
   const $nav = document.querySelector(".nav");
@@ -67,8 +68,8 @@ export default function changeUrl(requestedUrl, element) {
     }
   }
 
+  if (match.page === Register) match.page(element);
   if (
-    match.page === Register ||
     match.page === GameRoom ||
     match.page === Game ||
     match.page === EndGame

--- a/frontend/src/Router.js
+++ b/frontend/src/Router.js
@@ -6,7 +6,7 @@ import GameRoom from "./pages/GameRoom.js";
 import Register from "./pages/Register.js";
 import Redirect from "./components/Login/Redirect.js";
 import NotFound from "./pages/NotFound.js";
-import { getUserId } from "./state/State.js";
+import { getUserId, getIsLogin } from "./state/State.js";
 
 const routes = [
   { path: "/", page: Login, style: "login" },
@@ -55,13 +55,27 @@ export default function changeUrl(requestedUrl, element) {
   // if (match.page === EndGame) match.page("tournament", 1, 3, 1);
 
   if (
+    match.page === Main ||
     match.page === Register ||
     match.page === GameRoom ||
     match.page === Game ||
     match.page === EndGame
-  )
-    match.page(element);
-  else match.page();
+  ) {
+    if (getIsLogin() === null) {
+      changeUrl("/"); //로그인하지 않은 경우 로그인 페이지로 이동
+      return;
+    }
+  }
+
+  if (
+    match.page === Register ||
+    match.page === GameRoom ||
+    match.page === Game ||
+    match.page === EndGame
+  ) {
+    if (element) match.page(element);
+    else changeUrl("/main");
+  } else match.page();
 }
 
 window.addEventListener("popstate", () => {

--- a/frontend/src/components/Register/Nickname.js
+++ b/frontend/src/components/Register/Nickname.js
@@ -24,11 +24,9 @@ export default function Nickname(nickname) {
 
   $nicknameWrapper.appendChild($nickNameInputWrapper);
 
-  //todo: 닉네임 체크 기능 구현
   const $nicknameCheck = document.createElement("div");
   $nicknameCheck.classList.add("nicknameCheck");
-  // $nicknameCheck.innerHTML = "사용 중인 닉네임 입니다 등,, 에러 문구";
-  $nicknameCheck.style.display = "none"; //에러 문구가 없을 때는 display: none
+  $nicknameCheck.style.display = "none";
   $nicknameWrapper.appendChild($nicknameCheck);
 
   return $nicknameWrapper;

--- a/frontend/src/components/Register/SubmitButton.js
+++ b/frontend/src/components/Register/SubmitButton.js
@@ -7,7 +7,7 @@ import {
   setNewAccessToken,
   setNickname,
   setImage,
-  baseUrl
+  baseUrl,
 } from "../../state/State.js";
 
 function checkNickname(isDuplicate = false) {
@@ -76,9 +76,12 @@ function callApi(nickname, is2fa) {
           setIs2fa(data.result.is_2fa);
           setNickname(data.result.nickname);
           setImage(data.result.image_url);
-          changeUrl("/main"); //todo: 메인 페이지 이동 불필요. 닉네임 에러 삭제 필요
+          changeUrl("/main");
           resolve();
-        } else if (data.code === 409) {
+        } else if (
+          data.code === 400 &&
+          data.message === "members with this nickname already exists."
+        ) {
           //중복된 닉네임
           resolve(checkNickname(true));
         } else if (data.code === 401) {

--- a/frontend/src/components/Register/TwoFactorAuth.js
+++ b/frontend/src/components/Register/TwoFactorAuth.js
@@ -3,7 +3,7 @@ import {
   getAccessToken,
   setIs2fa,
   getIs2fa,
-  baseUrl
+  baseUrl,
 } from "../../state/State.js";
 import Modal from "../Modal/Modal.js";
 
@@ -89,14 +89,14 @@ export default function TwoFactorAuth(is2fa) {
           if (result === true) {
             setIs2fa(true);
           } else {
-            if (getIs2fa() === false) {
+            if (getIs2fa() === "false") {
               $twoFactorAuthActive.classList.remove("twoFactorAuthSelect");
               $twoFactorAuthDeactive.classList.add("twoFactorAuthSelect");
             }
           }
         });
       } else {
-        if (getIs2fa() === false) {
+        if (getIs2fa() === "false") {
           $twoFactorAuthActive.classList.remove("twoFactorAuthSelect");
           $twoFactorAuthDeactive.classList.add("twoFactorAuthSelect");
         }

--- a/frontend/src/pages/BotRoom.js
+++ b/frontend/src/pages/BotRoom.js
@@ -31,7 +31,7 @@ export default function BotRoom() {
     JSON.stringify({
       action: "fetch_bot_notify_messages",
       user_id: getUserId(),
-      timestamp: getTimestamp()
+      timestamp: getTimestamp(),
     })
   );
 
@@ -54,7 +54,7 @@ export default function BotRoom() {
       socket.send(
         JSON.stringify({
           action: "update_read_time",
-          room_name: 'bot',
+          room_name: "bot",
           timestamp: getTimestamp(),
         })
       );
@@ -67,4 +67,8 @@ export default function BotRoom() {
   $botRoomWrapper.appendChild(ChatInput());
   const $chatInput = document.querySelector(".chatInput");
   $chatInput.disabled = true;
+
+  window.onload = function () {
+    document.body.style.display = "block";
+  };
 }

--- a/frontend/src/pages/Chat.js
+++ b/frontend/src/pages/Chat.js
@@ -132,4 +132,8 @@ export default function Chat() {
     $overlay.classList.remove("showOverlay");
   });
   $sidebar.appendChild($overlay);
+
+  window.onload = function () {
+    document.body.style.display = "block";
+  };
 }

--- a/frontend/src/pages/ChatRoom.js
+++ b/frontend/src/pages/ChatRoom.js
@@ -167,4 +167,8 @@ export default function ChatRoom(user) {
       $chatsWrapper.scrollTop = $chatsWrapper.scrollHeight;
     }
   });
+
+  window.onload = function () {
+    document.body.style.display = "block";
+  };
 }

--- a/frontend/src/pages/EndGame.js
+++ b/frontend/src/pages/EndGame.js
@@ -34,17 +34,14 @@ export default async function EndGame({ info, result }) {
 
   var hasGameLeft = false;
   if (info.mode === "TOURNAMENT") {
-    hasGameLeft =
-      info.round === "SEMI_FINAL" && isWin;
+    hasGameLeft = info.round === "SEMI_FINAL" && isWin;
   }
   const $printBox = document.createElement("div");
   $printBox.classList.add("printBox");
   $app.appendChild($printBox);
-  $printBox.appendChild(
-    Result(info.mode, isWin, leftScore, rightScore)
-  );
+  $printBox.appendChild(Result(info.mode, isWin, leftScore, rightScore));
   $printBox.appendChild(EndBtn(info.mode, opponent.result, hasGameLeft));
-  if (info.mode === "2P" || isWin ) EndConfetti();
+  if (info.mode === "2P" || isWin) EndConfetti();
 
   if (hasGameLeft) {
     let sec = 5;
@@ -56,6 +53,10 @@ export default async function EndGame({ info, result }) {
       changeUrl("/gameroom", { round: "FINAL", room_id: info.room_id });
     }, sec * 1000);
   }
+
+  window.onload = function () {
+    document.body.style.display = "block";
+  };
 }
 
 //  mode | txt         | btn                   | modal

--- a/frontend/src/pages/Friends.js
+++ b/frontend/src/pages/Friends.js
@@ -171,4 +171,8 @@ export default async function Friends() {
       $listWrapper.appendChild(data);
     }
   });
+
+  window.onload = function () {
+    document.body.style.display = "block";
+  };
 }

--- a/frontend/src/pages/Game.js
+++ b/frontend/src/pages/Game.js
@@ -6,6 +6,7 @@ import RemoteBoard from "../components/Game/RemoteBoard.js";
 import changeUrl from "../Router.js";
 
 export default async function Game(data) {
+  document.body.style.display = "block";
   if (!data) {
     changeUrl("/main");
     return;

--- a/frontend/src/pages/GameRoom.js
+++ b/frontend/src/pages/GameRoom.js
@@ -5,6 +5,7 @@ import Modal from "../components/Modal/Modal.js";
 import RoomSocketManager from "../state/RoomSocketManager.js";
 
 export default function GameRoom(data) {
+  document.body.style.display = "block";
   if (!data) {
     changeUrl("/main");
     return;

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -13,4 +13,8 @@ export default async function Login() {
 
   $app.appendChild($title);
   $app.appendChild($loginButton);
+
+  window.onload = function () {
+    document.body.style.display = "block";
+  };
 }

--- a/frontend/src/pages/Main.js
+++ b/frontend/src/pages/Main.js
@@ -6,6 +6,7 @@ import { getUserId, checkSocketConnection } from "../state/State.js";
 import { getUserInfo } from "../components/Main/UserApi.js";
 
 export default async function Main() {
+  document.body.style.display = "block";
   Nav();
 
   checkSocketConnection();
@@ -46,4 +47,8 @@ export default async function Main() {
       await GameResultsScroll(id, isGeneral);
     }
   });
+
+  window.onload = function () {
+    document.body.style.display = "block";
+  };
 }

--- a/frontend/src/pages/NotFound.js
+++ b/frontend/src/pages/NotFound.js
@@ -43,4 +43,8 @@ export default function NotFound() {
   });
 
   $page.appendChild($homeButton);
+
+  window.onload = function () {
+    document.body.style.display = "block";
+  };
 }

--- a/frontend/src/pages/Profile.js
+++ b/frontend/src/pages/Profile.js
@@ -19,4 +19,8 @@ export default async function Profile(user) {
   //전적 정보
   const $gameInfo = GameInfo(userInfo.result);
   $chatsWrapper.appendChild($gameInfo);
+
+  window.onload = function () {
+    document.body.style.display = "block";
+  };
 }

--- a/frontend/src/pages/Register.js
+++ b/frontend/src/pages/Register.js
@@ -5,13 +5,7 @@ import Email from "../components/Register/Email.js";
 import Nickname from "../components/Register/Nickname.js";
 import TwoFactorAuth from "../components/Register/TwoFactorAuth.js";
 import SubmitButton from "../components/Register/SubmitButton.js";
-import {
-  getIsLogin,
-  getEmail,
-  getIs2fa,
-  getImage,
-  getNickname,
-} from "../state/State.js";
+import { getEmail, getIs2fa, getImage, getNickname } from "../state/State.js";
 
 export default function Register(isInit = false) {
   Nav();
@@ -50,4 +44,8 @@ export default function Register(isInit = false) {
   $registerWrapper.appendChild($submitButton);
 
   $app.appendChild($registerWrapper);
+
+  window.onload = function () {
+    document.body.style.display = "block";
+  };
 }

--- a/frontend/src/pages/Register.js
+++ b/frontend/src/pages/Register.js
@@ -12,13 +12,8 @@ import {
   getImage,
   getNickname,
 } from "../state/State.js";
-import changeUrl from "../Router.js";
 
 export default function Register(isInit = false) {
-  if (getIsLogin() === false) {
-    changeUrl("/"); //로그인 안되어있으면 로그인 페이지로 이동
-    return;
-  }
   Nav();
 
   const $app = document.querySelector(".App");


### PR DESCRIPTION
## ✅ PR 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드 수정
- [ ] 기능에 영향을 주지 않는 변경사항
- [x] 기능 향상
- [ ] 파일 or 폴더명 수정
- [ ] 파일 or 폴더 삭제

## 📰 관련 이슈
<!---- 아래에 주소에 이슈번호를 넣어주세요! ---->
<!---- ex) https://github.com/42EASY/PongPongPingPong/issues/1 ---->
- https://github.com/42EASY/PongPongPingPong/issues/

## 📝 PR 내용
<!---- 해당 PR에 어떤 작업을 하였는지 설명해주세요. ---->
- register 페이지의 중복 닉네임 API 응답이 명세와 달라 에러 발생된 부분 수정
- register 페이지의 2차인증 활성화 클릭 후 비정상 종료 시 다시 비활성화로 돌아가지 않던 부분 수정
- 로그인 없이/인자 없이 url로 페이지 이동하는 경우 로그인 페이지/메인 페이지로 이동되도록 적용
- 모든 페이지에서 css 적용 전까지 display: none 처리 적용 하였습니다.
