### PR TITLE
fix: 토너먼트 결승 게임을 위한 게임방에 입장이 안되는 현상 수정

### DIFF
--- a/backend/transcendence/games/game_room_consumer.py
+++ b/backend/transcendence/games/game_room_consumer.py
@@ -62,12 +62,6 @@ class GameRoomConsumer(AsyncJsonWebsocketConsumer):
         join_info = parsed_value["join_user"]
         join_final_info = parsed_value["join_final_user"]
 
-        #registered_user 값 제거
-        idx = -1
-        for info in registered_info:
-            idx = idx + 1
-            if (info["user_id"] == int(self.user.id)):
-                parsed_value["registered_user"].pop(idx)
 
         #join_user 값 제거
         idx = -1


### PR DESCRIPTION
## ✅ PR 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드 수정
- [ ] 기능에 영향을 주지 않는 변경사항
- [ ] 기능 향상
- [ ] 파일 or 폴더명 수정
- [ ] 파일 or 폴더 삭제

## 📰 관련 이슈
<!---- 아래에 주소에 이슈번호를 넣어주세요! ---->
<!---- ex) https://github.com/42EASY/PongPongPingPong/issues/1 ---->
- https://github.com/42EASY/PongPongPingPong/issues/283

## 📝 PR 내용
<!---- 해당 PR에 어떤 작업을 하였는지 설명해주세요. ---->
- 토너먼트 결승 게임이 안되는 현상 발생
- 준결승 후 disconnect 시에 토너먼트의 게임 registered가 삭제되어, 결승 게임이 안되는 현상이 발생하였고 이를 수정함
